### PR TITLE
fixup: dep: change `serde-xml-rs` dependency

### DIFF
--- a/bnr-xfs/Cargo.lock
+++ b/bnr-xfs/Cargo.lock
@@ -46,21 +46,11 @@ dependencies = [
  "log",
  "nusb",
  "paste",
- "rusb",
  "serde",
- "serde-xml-rs",
+ "serde-xml-rust",
  "serde_json",
  "time",
  "xml-rs",
-]
-
-[[package]]
-name = "cc"
-version = "1.0.83"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1174fb0b6ec23863f8b971027804a42614e347eafb0a95bf0b12cdae21fc4d0"
-dependencies = [
- "libc",
 ]
 
 [[package]]
@@ -194,18 +184,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13e3bf6590cbc649f4d1a3eefc9d5d6eb746f5200ffb04e5e142700b8faa56e7"
 
 [[package]]
-name = "libusb1-sys"
-version = "0.6.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9d0e2afce4245f2c9a418511e5af8718bcaf2fa408aefb259504d1a9cb25f27"
-dependencies = [
- "cc",
- "libc",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
 name = "linux-raw-sys"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -274,12 +252,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8afb450f006bf6385ca15ef45d71d2288452bc3683ce2e2cacc0d18e4be60b58"
 
 [[package]]
-name = "pkg-config"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.67"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -327,16 +299,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dbb5fb1acd8a1a18b3dd5be62d25485eb770e05afb408a9627d14d451bae12da"
 
 [[package]]
-name = "rusb"
-version = "0.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "45fff149b6033f25e825cbb7b2c625a11ee8e6dac09264d49beb125e39aa97bf"
-dependencies = [
- "libc",
- "libusb1-sys",
-]
-
-[[package]]
 name = "rustix"
 version = "0.38.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -365,9 +327,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde-xml-rs"
+name = "serde-xml-rust"
 version = "0.6.0"
-source = "git+https://github.com/cr8t/serde-xml-rs#d126862a83dc4cc8a033accade1314139f5a0c6c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "662b17c24bfc6e11d411126768b727fbca2f33b7c2b6e21cdbb7cc31541c60d4"
 dependencies = [
  "serde",
  "thiserror",
@@ -478,12 +441,6 @@ name = "unicode-ident"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3354b9ac3fae1ff6755cb6db53683adb661634f67557942dea4facebec0fee4b"
-
-[[package]]
-name = "vcpkg"
-version = "0.2.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "winapi"

--- a/bnr-xfs/Cargo.toml
+++ b/bnr-xfs/Cargo.toml
@@ -30,9 +30,9 @@ version= "0.3"
 package = "time"
 features = ["formatting", "macros", "parsing"]
 
-[dependencies.serde-xml-rs]
+[dependencies.serde-xml]
 version = "0.6"
-git = "https://github.com/cr8t/serde-xml-rs"
+package = "serde-xml-rust"
 default-features = false
 
 [dependencies.serde]

--- a/bnr-xfs/src/error.rs
+++ b/bnr-xfs/src/error.rs
@@ -29,8 +29,8 @@ pub enum Error {
     BnrUsb(UsbError),
 }
 
-impl From<serde_xml_rs::Error> for Error {
-    fn from(err: serde_xml_rs::Error) -> Self {
+impl From<serde_xml::Error> for Error {
+    fn from(err: serde_xml::Error) -> Self {
         Self::Serde(format!("{err}"))
     }
 }

--- a/bnr-xfs/src/xfs.rs
+++ b/bnr-xfs/src/xfs.rs
@@ -22,7 +22,7 @@ pub fn to_string<S: serde::Serialize>(s: S) -> Result<String> {
         xml::EmitterConfig::new().pad_self_closing(false),
     );
 
-    let mut ser = serde_xml_rs::Serializer::new_from_writer(event_writer);
+    let mut ser = serde_xml::Serializer::new_from_writer(event_writer);
     s.serialize(&mut ser)?;
 
     Ok(String::from_utf8(sink)?)
@@ -38,14 +38,14 @@ pub fn to_iso_string<S: serde::Serialize>(s: S) -> Result<String> {
     );
 
     let mut ser =
-        serde_xml_rs::Serializer::new_from_writer(event_writer).with_encoding("ISO-8859-1");
+        serde_xml::Serializer::new_from_writer(event_writer).with_encoding("ISO-8859-1");
     s.serialize(&mut ser)?;
 
     Ok(String::from_utf8(sink)?)
 }
 
 pub fn from_str<'de, T: serde::Deserialize<'de>>(xml_str: &'de str) -> Result<T> {
-    let mut de = serde_xml_rs::Deserializer::new(xml::EventReader::new_with_config(
+    let mut de = serde_xml::Deserializer::new(xml::EventReader::new_with_config(
         xml_str.as_bytes(),
         xml::ParserConfig::new()
             .trim_whitespace(true)


### PR DESCRIPTION
Update to the published version of the `serde-xml-rs` fork.