### PR TITLE
version: bump to 0.1.1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bnr"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 authors = ["BNR Rust Developers"]
 description = "Pure Rust implementation of the BNR XFS USB communication protocol"


### PR DESCRIPTION
Bumps the patch release to `v0.1.1` for denominations module.