### PR TITLE
version: bump bnr-xfs to v0.1.2

### DIFF
--- a/bnr-xfs/Cargo.lock
+++ b/bnr-xfs/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "b4682ae6287fcf752ecaabbfcc7b6f9b72aa33933dc23a554d853aea8eea8635"
 
 [[package]]
 name = "bnr-xfs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "base64",
  "currency-iso4217",

--- a/bnr-xfs/Cargo.toml
+++ b/bnr-xfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bnr-xfs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["BNR Rust Developers"]
 description = "Pure Rust implementation of the BNR XFS USB"


### PR DESCRIPTION
Bumps the `bnr-xfs` patch release to v0.1.2 to include added commands.