### PR TITLE
feature: add `query_billset_ids` function

### DIFF
--- a/bnr-xfs/src/denominations/billset.rs
+++ b/bnr-xfs/src/denominations/billset.rs
@@ -128,9 +128,9 @@ impl BillsetInfo {
 impl fmt::Display for BillsetInfo {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         write!(f, "{{")?;
-        write!(f, r#""billset_id":{}"#, self.billset_id)?;
-        write!(f, r#""module_type":{}"#, self.module_type)?;
-        write!(f, r#""component_type":{}"#, self.component_type)?;
+        write!(f, r#""billset_id":{},"#, self.billset_id)?;
+        write!(f, r#""module_type":{},"#, self.module_type)?;
+        write!(f, r#""component_type":{},"#, self.component_type)?;
         write!(f, r#""version":{}"#, self.version)?;
         write!(f, "}}")
     }

--- a/src/denominations.rs
+++ b/src/denominations.rs
@@ -1,6 +1,6 @@
 //! Functions for denomination operations.
 
-use bnr_xfs::DenominationList;
+use bnr_xfs::{BillsetIdList, DenominationList};
 
 use crate::{with_handle, Result};
 
@@ -38,4 +38,11 @@ pub fn query_denominations() -> Result<DenominationList> {
 ///   - `#XFS_E_FAILURE` - a command is already running on the BNR or an internal error occured.
 pub fn update_denominations(request: &DenominationList) -> Result<()> {
     with_handle::<()>(|h| h.update_denominations(request))
+}
+
+/// Queries the device for the configured [BillsetIdList].
+///
+/// **NOTE** Firmware Compatibility: This function requires a BNR FW v1.12.0 or newer. With older FW versions, the return will be #XFS_E_NOT_SUPPORTED.
+pub fn query_billset_ids() -> Result<BillsetIdList> {
+    with_handle::<BillsetIdList>(|h| h.query_billset_ids())
 }

--- a/tests/e2e_tests/common.rs
+++ b/tests/e2e_tests/common.rs
@@ -4,5 +4,6 @@ use std::sync::{Mutex, MutexGuard};
 static INIT: Mutex<()> = Mutex::new(());
 
 pub fn init() -> Result<MutexGuard<'static, ()>> {
+    env_logger::try_init().ok();
     Ok(INIT.lock()?)
 }

--- a/tests/e2e_tests/denominations.rs
+++ b/tests/e2e_tests/denominations.rs
@@ -1,0 +1,56 @@
+use bnr::{self, denominations, init, Result};
+use std::{thread, time};
+
+use crate::e2e_tests::common;
+
+#[test]
+fn test_query_denominations() -> Result<()> {
+    let _lock = common::init();
+
+    init::open(None, None, None)?;
+    init::reset()?;
+
+    thread::sleep(time::Duration::from_secs(1));
+
+    let list = denominations::query_denominations()?;
+    log::debug!("Denominations list: {list}");
+
+    init::close()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_update_denominations() -> Result<()> {
+    let _lock = common::init();
+
+    init::open(None, None, None)?;
+    init::reset()?;
+
+    thread::sleep(time::Duration::from_secs(1));
+
+    let list = denominations::query_denominations()?;
+    log::debug!("Denominations list: {list}");
+    denominations::update_denominations(&list)?;
+
+    init::close()?;
+
+    Ok(())
+}
+
+#[test]
+fn test_query_billset_ids() -> Result<()> {
+    let _lock = common::init();
+
+    init::open(None, None, None)?;
+    init::reset()?;
+
+    thread::sleep(time::Duration::from_secs(1));
+
+    let ids = denominations::query_billset_ids()?;
+    log::debug!("Billset IDs: {ids}");
+
+    init::close()?;
+
+    Ok(())
+}

--- a/tests/e2e_tests/mod.rs
+++ b/tests/e2e_tests/mod.rs
@@ -1,5 +1,6 @@
 mod cash;
 mod common;
+mod denominations;
 mod init;
 mod maintenance;
 mod status;


### PR DESCRIPTION
Adds `query_billset_ids` function to the top-level API.

Fixes formatting for `BillsetIdList` display.