### PR TITLE
feature: bill acceptance history method

### DIFF
--- a/bnr-xfs/src/cash_unit.rs
+++ b/bnr-xfs/src/cash_unit.rs
@@ -29,7 +29,7 @@ pub use unit_id::*;
 ///
 /// Describes the entire set of [LogicalCashUnit]s and [PhysicalCashUnit]s present on a device.
 #[repr(C)]
-#[derive(Clone, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct CashUnit {
     transport_count: TransportCount,
     logical_cash_unit_list: LogicalCashUnitList,

--- a/bnr-xfs/src/cash_unit/counters.rs
+++ b/bnr-xfs/src/cash_unit/counters.rs
@@ -1,35 +1,45 @@
-use std::fmt;
-
-use crate::xfs::xfs_struct::XfsMember;
-use crate::{impl_xfs_struct, Error, Result};
+use crate::create_xfs_struct;
 
 mod counts;
 
 pub use counts::*;
 
-/// Represents extended counters for a cash unit.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ExtendedCounters {
-    deposit: Option<DepositCounters>,
-    dispense: Option<DispenseCounters>,
-}
+create_xfs_struct!(
+    DepositCounters,
+    "depositCounters",
+    [
+        deposit_count: DepositCount,
+        retracted_count: RetractedCount,
+        emptied_count: EmptiedCount,
+        forgery_count: ForgeryCount,
+        disappeared_count: DisappearedCount
+    ],
+    "Represents counters for deposits."
+);
 
-impl ExtendedCounters {
-    /// Creates a new [ExtendedCounters].
-    pub const fn new() -> Self {
-        Self {
-            deposit: None,
-            dispense: None,
-        }
-    }
-}
+impl Copy for DepositCounters {}
+
+create_xfs_struct!(
+    DispenseCounters,
+    "dispenseCounters",
+    [dispense_count: DispenseCount, reject_count: RejectCount],
+    "Represents counters for dispensed notes."
+);
+
+impl Copy for DispenseCounters {}
+
+create_xfs_struct!(
+    ExtendedCounters,
+    "extendedCounters",
+    [deposit: DepositCounters, dispense: DispenseCounters],
+    "Represents extended counters for a cash unit."
+);
 
 impl From<DepositCounters> for ExtendedCounters {
     fn from(val: DepositCounters) -> Self {
         Self {
-            deposit: Some(val),
-            dispense: None,
+            deposit: val,
+            dispense: DispenseCounters::new(),
         }
     }
 }
@@ -43,8 +53,8 @@ impl From<&DepositCounters> for ExtendedCounters {
 impl From<DispenseCounters> for ExtendedCounters {
     fn from(val: DispenseCounters) -> Self {
         Self {
-            deposit: None,
-            dispense: Some(val),
+            deposit: DepositCounters::new(),
+            dispense: val,
         }
     }
 }
@@ -55,183 +65,4 @@ impl From<&DispenseCounters> for ExtendedCounters {
     }
 }
 
-impl fmt::Display for ExtendedCounters {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{{")?;
-
-        if let Some(d) = self.deposit.as_ref() {
-            write!(f, r#""deposit":{d}"#)?;
-        }
-
-        if let Some(d) = self.dispense.as_ref() {
-            if self.deposit.is_some() {
-                write!(f, ",")?;
-            }
-
-            write!(f, r#""dispense":{d}"#)?;
-        }
-
-        write!(f, "}}")
-    }
-}
-
-impl_xfs_struct!(
-    ExtendedCounters,
-    "extendedCounters",
-    [deposit: DepositCounters, dispense: DispenseCounters]
-);
-
-/// Represents counters for deposits.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DepositCounters {
-    deposit_count: DepositCount,
-    retracted_count: RetractedCount,
-    emptied_count: EmptiedCount,
-    forgery_count: ForgeryCount,
-    disappeared_count: DisappearedCount,
-}
-
-impl DepositCounters {
-    /// Creates a new [DepositCounters].
-    pub const fn new() -> Self {
-        Self {
-            deposit_count: DepositCount::new(),
-            retracted_count: RetractedCount::new(),
-            emptied_count: EmptiedCount::new(),
-            forgery_count: ForgeryCount::new(),
-            disappeared_count: DisappearedCount::new(),
-        }
-    }
-}
-
-impl fmt::Display for DepositCounters {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{{")?;
-        write!(f, r#""deposit_count":{},"#, self.deposit_count)?;
-        write!(f, r#""retracted_count":{},"#, self.retracted_count)?;
-        write!(f, r#""emptied_count":{},"#, self.emptied_count)?;
-        write!(f, r#""forgery_count":{},"#, self.forgery_count)?;
-        write!(f, r#""disappeared_count":{}"#, self.disappeared_count)?;
-        write!(f, "}}")
-    }
-}
-
-impl_xfs_struct!(
-    DepositCounters,
-    "depositCounters",
-    [
-        deposit_count: DepositCount,
-        retracted_count: RetractedCount,
-        emptied_count: EmptiedCount,
-        forgery_count: ForgeryCount,
-        disappeared_count: DisappearedCount
-    ]
-);
-
-impl From<Option<&DepositCounters>> for XfsMember {
-    fn from(val: Option<&DepositCounters>) -> Self {
-        match val {
-            Some(v) => Self::create(DepositCounters::xfs_name(), v.into()),
-            None => Self::new().with_name(DepositCounters::xfs_name()),
-        }
-    }
-}
-
-impl From<Option<DepositCounters>> for XfsMember {
-    fn from(val: Option<DepositCounters>) -> Self {
-        val.as_ref().into()
-    }
-}
-
-impl TryFrom<&XfsMember> for Option<DepositCounters> {
-    type Error = Error;
-
-    fn try_from(val: &XfsMember) -> Result<Self> {
-        match (val.name(), val.value().xfs_struct()) {
-            (n, Some(v)) if n == DepositCounters::xfs_name() => Ok(Some(v.try_into()?)),
-            (_n, None) => Ok(None),
-            _ => Err(Error::Xfs(format!(
-                "Expected DepositCounters XfsMember, have: {val}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<XfsMember> for Option<DepositCounters> {
-    type Error = Error;
-
-    fn try_from(val: XfsMember) -> Result<Self> {
-        (&val).try_into()
-    }
-}
-
-/// Represents counters for dispensed notes.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DispenseCounters {
-    dispense_count: DispenseCount,
-    reject_count: RejectCount,
-}
-
-impl DispenseCounters {
-    /// Creates a new [DispenseCounters].
-    pub const fn new() -> Self {
-        Self {
-            dispense_count: DispenseCount::new(),
-            reject_count: RejectCount::new(),
-        }
-    }
-}
-
-impl fmt::Display for DispenseCounters {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{{")?;
-        write!(f, r#""dispense_count":{}"#, self.dispense_count)?;
-        write!(f, r#""reject_count":{}"#, self.reject_count)?;
-        write!(f, "}}")
-    }
-}
-
-impl_xfs_struct!(
-    DispenseCounters,
-    "dispenseCounters",
-    [dispense_count: DispenseCount, reject_count: RejectCount]
-);
-
-impl From<Option<&DispenseCounters>> for XfsMember {
-    fn from(val: Option<&DispenseCounters>) -> Self {
-        match val {
-            Some(v) => Self::create(DispenseCounters::xfs_name(), v.into()),
-            None => Self::new().with_name(DispenseCounters::xfs_name()),
-        }
-    }
-}
-
-impl From<Option<DispenseCounters>> for XfsMember {
-    fn from(val: Option<DispenseCounters>) -> Self {
-        val.as_ref().into()
-    }
-}
-
-impl TryFrom<&XfsMember> for Option<DispenseCounters> {
-    type Error = Error;
-
-    fn try_from(val: &XfsMember) -> Result<Self> {
-        match (val.name(), val.value().xfs_struct()) {
-            (n, Some(v)) if n == DispenseCounters::xfs_name() => Ok(Some(v.try_into()?)),
-            (_n, None) => Ok(None),
-            _ => Err(Error::Xfs(format!(
-                "Expected DispenseCounters XfsMember, have: {val}"
-            ))),
-        }
-    }
-}
-
-impl TryFrom<XfsMember> for Option<DispenseCounters> {
-    type Error = Error;
-
-    fn try_from(val: XfsMember) -> Result<Self> {
-        (&val).try_into()
-    }
-}
+impl Copy for ExtendedCounters {}

--- a/bnr-xfs/src/cash_unit/counters/counts.rs
+++ b/bnr-xfs/src/cash_unit/counters/counts.rs
@@ -1,283 +1,33 @@
-use std::fmt;
+use crate::create_xfs_i4;
 
-use crate::impl_xfs_i4;
-
-/// Represents the [DepositCounters](super::DepositCounters) deposit count.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DepositCount(u32);
-
-impl DepositCount {
-    /// Creates a new [DepositCount].
-    pub const fn new() -> Self {
-        Self(0)
-    }
-
-    /// Creates a new [DepositCount] from the provided parameter.
-    pub const fn create(val: u32) -> Self {
-        Self(val)
-    }
-
-    /// Gets the inner representation of the [DepositCount].
-    pub const fn inner(&self) -> u32 {
-        self.0
-    }
-
-    /// Sets the inner representation of the [DepositCount].
-    pub fn set_inner(&mut self, val: u32) {
-        self.0 = val;
-    }
-
-    /// Converts into the inner representation of the [DepositCount].
-    pub fn into_inner(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for DepositCount {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inner())
-    }
-}
-
-impl_xfs_i4!(DepositCount, "depositCount");
-
-/// Represents the [DepositCounters](super::DepositCounters) retracted count.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RetractedCount(u32);
-
-impl RetractedCount {
-    /// Creates a new [RetractedCount].
-    pub const fn new() -> Self {
-        Self(0)
-    }
-
-    /// Creates a new [RetractedCount] from the provided parameter.
-    pub const fn create(val: u32) -> Self {
-        Self(val)
-    }
-
-    /// Gets the inner representation of the [RetractedCount].
-    pub const fn inner(&self) -> u32 {
-        self.0
-    }
-
-    /// Sets the inner representation of the [RetractedCount].
-    pub fn set_inner(&mut self, val: u32) {
-        self.0 = val;
-    }
-
-    /// Converts into the inner representation of the [RetractedCount].
-    pub fn into_inner(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for RetractedCount {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inner())
-    }
-}
-
-impl_xfs_i4!(RetractedCount, "retractedCount");
-
-/// Represents the [DepositCounters](super::DepositCounters) emptied count.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct EmptiedCount(u32);
-
-impl EmptiedCount {
-    /// Creates a new [EmptiedCount].
-    pub const fn new() -> Self {
-        Self(0)
-    }
-
-    /// Creates a new [EmptiedCount] from the provided parameter.
-    pub const fn create(val: u32) -> Self {
-        Self(val)
-    }
-
-    /// Gets the inner representation of the [EmptiedCount].
-    pub const fn inner(&self) -> u32 {
-        self.0
-    }
-
-    /// Sets the inner representation of the [EmptiedCount].
-    pub fn set_inner(&mut self, val: u32) {
-        self.0 = val;
-    }
-
-    /// Converts into the inner representation of the [EmptiedCount].
-    pub fn into_inner(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for EmptiedCount {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inner())
-    }
-}
-
-impl_xfs_i4!(EmptiedCount, "emptiedCount");
-
-/// Represents the [DepositCounters](super::DepositCounters) forgery count.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct ForgeryCount(u32);
-
-impl ForgeryCount {
-    /// Creates a new [ForgeryCount].
-    pub const fn new() -> Self {
-        Self(0)
-    }
-
-    /// Creates a new [ForgeryCount] from the provided parameter.
-    pub const fn create(val: u32) -> Self {
-        Self(val)
-    }
-
-    /// Gets the inner representation of the [ForgeryCount].
-    pub const fn inner(&self) -> u32 {
-        self.0
-    }
-
-    /// Sets the inner representation of the [ForgeryCount].
-    pub fn set_inner(&mut self, val: u32) {
-        self.0 = val;
-    }
-
-    /// Converts into the inner representation of the [ForgeryCount].
-    pub fn into_inner(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for ForgeryCount {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inner())
-    }
-}
-
-impl_xfs_i4!(ForgeryCount, "forgeryCount");
-
-/// Represents the [DepositCounters](super::DepositCounters) disappeared count.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DisappearedCount(u32);
-
-impl DisappearedCount {
-    /// Creates a new [DisappearedCount].
-    pub const fn new() -> Self {
-        Self(0)
-    }
-
-    /// Creates a new [DisappearedCount] from the provided parameter.
-    pub const fn create(val: u32) -> Self {
-        Self(val)
-    }
-
-    /// Gets the inner representation of the [DisappearedCount].
-    pub const fn inner(&self) -> u32 {
-        self.0
-    }
-
-    /// Sets the inner representation of the [DisappearedCount].
-    pub fn set_inner(&mut self, val: u32) {
-        self.0 = val;
-    }
-
-    /// Converts into the inner representation of the [DisappearedCount].
-    pub fn into_inner(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for DisappearedCount {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inner())
-    }
-}
-
-impl_xfs_i4!(DisappearedCount, "disappearedCount");
-
-/// Represents the [DispenseCounters](super::DispenseCounters) reject count.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct DispenseCount(u32);
-
-impl DispenseCount {
-    /// Creates a new [DispenseCount].
-    pub const fn new() -> Self {
-        Self(0)
-    }
-
-    /// Creates a new [DispenseCount] from the provided parameter.
-    pub const fn create(val: u32) -> Self {
-        Self(val)
-    }
-
-    /// Gets the inner representation of the [DispenseCount].
-    pub const fn inner(&self) -> u32 {
-        self.0
-    }
-
-    /// Sets the inner representation of the [DispenseCount].
-    pub fn set_inner(&mut self, val: u32) {
-        self.0 = val;
-    }
-
-    /// Converts into the inner representation of the [DispenseCount].
-    pub fn into_inner(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for DispenseCount {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inner())
-    }
-}
-
-impl_xfs_i4!(DispenseCount, "dispenseCount");
-
-/// Represents the [DispenseCounters](super::DispenseCounters) reject count.
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct RejectCount(u32);
-
-impl RejectCount {
-    /// Creates a new [RejectCount].
-    pub const fn new() -> Self {
-        Self(0)
-    }
-
-    /// Creates a new [RejectCount] from the provided parameter.
-    pub const fn create(val: u32) -> Self {
-        Self(val)
-    }
-
-    /// Gets the inner representation of the [RejectCount].
-    pub const fn inner(&self) -> u32 {
-        self.0
-    }
-
-    /// Sets the inner representation of the [RejectCount].
-    pub fn set_inner(&mut self, val: u32) {
-        self.0 = val;
-    }
-
-    /// Converts into the inner representation of the [RejectCount].
-    pub fn into_inner(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for RejectCount {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inner())
-    }
-}
-
-impl_xfs_i4!(RejectCount, "rejectCount");
+create_xfs_i4!(
+    DepositCount,
+    "depositCount",
+    "Represents the deposit count."
+);
+create_xfs_i4!(
+    RetractedCount,
+    "retractedCount",
+    "Represents the retracted count."
+);
+create_xfs_i4!(
+    EmptiedCount,
+    "emptiedCount",
+    "Represents the emptied count."
+);
+create_xfs_i4!(
+    ForgeryCount,
+    "forgeryCount",
+    "Represents the forgery count."
+);
+create_xfs_i4!(
+    DisappearedCount,
+    "disappearedCount",
+    "Represents the disappeared count."
+);
+create_xfs_i4!(
+    DispenseCount,
+    "dispenseCount",
+    "Represents the dispense count."
+);
+create_xfs_i4!(RejectCount, "rejectCount", "Represents the reject count.");

--- a/bnr-xfs/src/cash_unit/logical_cash_unit.rs
+++ b/bnr-xfs/src/cash_unit/logical_cash_unit.rs
@@ -11,7 +11,7 @@ pub use list::*;
 
 /// Represents a logical cash unit, and its parameters.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Debug, Default, PartialEq)]
 pub struct LogicalCashUnit {
     cash_type: CashType,
     secondary_cash_types: CashTypeList,

--- a/bnr-xfs/src/cash_unit/logical_cash_unit/list.rs
+++ b/bnr-xfs/src/cash_unit/logical_cash_unit/list.rs
@@ -1,6 +1,6 @@
 use std::{cmp, fmt};
 
-use crate::{arrays, impl_xfs_array, impl_xfs_struct, MaxSize, Size};
+use crate::{impl_xfs_array, impl_xfs_struct, MaxSize, Size};
 
 use super::*;
 
@@ -8,10 +8,9 @@ use super::*;
 pub const LCU_LIST_LEN: usize = 83;
 
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LogicalCashUnitItems {
     size: Size,
-    #[serde(with = "arrays")]
     items: [LogicalCashUnit; LCU_LIST_LEN],
 }
 
@@ -102,7 +101,7 @@ impl_xfs_array!(LogicalCashUnitItems, "items");
 
 /// Represents a list of [LogicalCashUnit]s.
 #[repr(C)]
-#[derive(Clone, Copy, Debug, PartialEq, serde::Deserialize, serde::Serialize)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub struct LogicalCashUnitList {
     max_size: MaxSize,
     size: Size,

--- a/bnr-xfs/src/currency/cash_type.rs
+++ b/bnr-xfs/src/currency/cash_type.rs
@@ -1,90 +1,18 @@
 use std::fmt;
 
-use crate::{impl_xfs_array, impl_xfs_i4, impl_xfs_struct, Size};
+use crate::{create_xfs_i4, impl_xfs_array, impl_xfs_struct, Size};
 
 use super::CurrencyCode;
 
 pub const CASH_TYPE_LIST_LEN: usize = 14;
 
-/// Represents the value of a [CashType].
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Value(u32);
+create_xfs_i4!(Value, "value", "Represents the value of a [CashType].");
 
-impl Value {
-    /// Creates a new [Value].
-    pub const fn new() -> Self {
-        Self(0)
-    }
-
-    /// Creates a new [Value] from the provided parameter.
-    pub const fn create(c: u32) -> Self {
-        Self(c)
-    }
-
-    /// Gets the inner representation of the [Value].
-    pub const fn inner(&self) -> u32 {
-        self.0
-    }
-
-    /// Sets the inner representation of the [Value].
-    pub fn set_inner(&mut self, v: u32) {
-        self.0 = v;
-    }
-
-    /// Converts into the inner representation of the [Value].
-    pub fn into_inner(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for Value {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inner())
-    }
-}
-
-impl_xfs_i4!(Value, "value");
-
-/// Represents the value of a [CashType].
-#[repr(C)]
-#[derive(Clone, Copy, Debug, Default, PartialEq, serde::Deserialize, serde::Serialize)]
-pub struct Variant(u32);
-
-impl Variant {
-    /// Creates a new [Variant].
-    pub const fn new() -> Self {
-        Self(0)
-    }
-
-    /// Creates a new [Variant] from the provided parameter.
-    pub const fn create(c: u32) -> Self {
-        Self(c)
-    }
-
-    /// Gets the inner representation of the [Variant].
-    pub const fn inner(&self) -> u32 {
-        self.0
-    }
-
-    /// Sets the inner representation of the [Variant].
-    pub fn set_inner(&mut self, v: u32) {
-        self.0 = v;
-    }
-
-    /// Converts into the inner representation of the [Variant].
-    pub fn into_inner(self) -> u32 {
-        self.0
-    }
-}
-
-impl fmt::Display for Variant {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", self.inner())
-    }
-}
-
-impl_xfs_i4!(Variant, "variant");
+create_xfs_i4!(
+    Variant,
+    "variant",
+    "Represents the variant of a [CashType]."
+);
 
 /// Represents a cash type ISO currency code, value, and variant.
 #[repr(C)]

--- a/bnr-xfs/src/device_handle.rs
+++ b/bnr-xfs/src/device_handle.rs
@@ -11,6 +11,7 @@ use crate::currency::{CashOrder, CurrencyCode};
 use crate::denominations::BillsetIdList;
 use crate::denominations::DenominationList;
 use crate::dispense::DispenseRequest;
+use crate::history::BillAcceptanceHistory;
 use crate::status::CdrStatus;
 use crate::xfs;
 use crate::{Error, Result};
@@ -501,6 +502,11 @@ impl DeviceHandle {
     /// **NOTE** Firmware Compatibility: This function requires a BNR FW v1.12.0 or newer. With older FW versions, the return will be #XFS_E_NOT_SUPPORTED.
     pub fn query_billset_ids(&self) -> Result<BillsetIdList> {
         self.query_billset_ids_inner()
+    }
+
+    /// Gets the BNR [BillAcceptanceHistory].
+    pub fn get_bill_acceptance_history(&self) -> Result<BillAcceptanceHistory> {
+        self.get_bill_acceptance_history_inner()
     }
 
     /// Gets a reference to the [UsbDeviceHandle].

--- a/bnr-xfs/src/device_handle/inner.rs
+++ b/bnr-xfs/src/device_handle/inner.rs
@@ -710,4 +710,12 @@ impl DeviceHandle {
         usb.write_call(&call)?;
         usb.read_response(call.name()?)?.try_into()
     }
+
+    pub(crate) fn get_bill_acceptance_history_inner(&self) -> Result<BillAcceptanceHistory> {
+        let call = XfsMethodCall::create(XfsMethodName::GetBillAcceptanceHistory, []);
+        let usb = self.usb();
+
+        usb.write_call(&call)?;
+        usb.read_response(call.name()?)?.try_into()
+    }
 }

--- a/bnr-xfs/src/history.rs
+++ b/bnr-xfs/src/history.rs
@@ -1,0 +1,23 @@
+mod bill_acceptance_history;
+mod cash_type_acceptance_history;
+mod cash_type_recycle_history;
+mod counts;
+mod extraction_reject_details;
+mod inlet_acceptance_history;
+mod insertion_reject_details;
+mod loader_acceptance_history;
+mod loader_slot_acceptance_history;
+mod recognition_reject_details;
+mod transport_reject_details;
+
+pub use bill_acceptance_history::*;
+pub use cash_type_acceptance_history::*;
+pub use cash_type_recycle_history::*;
+pub use counts::*;
+pub use extraction_reject_details::*;
+pub use inlet_acceptance_history::*;
+pub use insertion_reject_details::*;
+pub use loader_acceptance_history::*;
+pub use loader_slot_acceptance_history::*;
+pub use recognition_reject_details::*;
+pub use transport_reject_details::*;

--- a/bnr-xfs/src/history/bill_acceptance_history.rs
+++ b/bnr-xfs/src/history/bill_acceptance_history.rs
@@ -1,0 +1,41 @@
+use crate::create_xfs_struct;
+use crate::xfs::method_response::XfsMethodResponse;
+use crate::{Error, Result};
+
+use super::{CashTypeRecycleHistoryItems, InletAcceptanceHistory, LoaderAcceptanceHistory};
+
+create_xfs_struct!(
+    BillAcceptanceHistory,
+    "billAcceptanceHistory",
+    [
+        inlet_acceptance_history: InletAcceptanceHistory,
+        loader_acceptance_history: LoaderAcceptanceHistory,
+        recycle_acceptance_history: CashTypeRecycleHistoryItems
+    ],
+    "Represents the bill acceptance history."
+);
+
+impl TryFrom<&XfsMethodResponse> for BillAcceptanceHistory {
+    type Error = Error;
+
+    fn try_from(val: &XfsMethodResponse) -> Result<Self> {
+        val.as_params()?
+            .params()
+            .iter()
+            .map(|m| m.inner())
+            .find(|m| m.value().xfs_struct().is_some())
+            .ok_or(Error::Xfs(format!(
+                "Expected BillAcceptanceHistory XfsMethodResponse, have: {val}"
+            )))?
+            .value()
+            .try_into()
+    }
+}
+
+impl TryFrom<XfsMethodResponse> for BillAcceptanceHistory {
+    type Error = Error;
+
+    fn try_from(val: XfsMethodResponse) -> Result<Self> {
+        (&val).try_into()
+    }
+}

--- a/bnr-xfs/src/history/cash_type_acceptance_history.rs
+++ b/bnr-xfs/src/history/cash_type_acceptance_history.rs
@@ -1,0 +1,31 @@
+use crate::{create_xfs_array, create_xfs_struct};
+use crate::{CashType, ForgeryCount};
+
+use super::{ConfusionCount, FitnessRejectCount, SuspectCount, ValidCount, ValidUnfitCount};
+
+pub const CASH_TYPE_HISTORY_LIST_LEN: usize = 61;
+pub const CASH_TYPE_HISTORY_DEFAULT: CashTypeAcceptanceHistory = CashTypeAcceptanceHistory::new();
+
+create_xfs_struct!(
+    CashTypeAcceptanceHistory,
+    "cashTypeAcceptanceHistory",
+    [
+        cash_type: CashType,
+        confusion_count: ConfusionCount,
+        forgery_count: ForgeryCount,
+        fitness_reject_count: FitnessRejectCount,
+        valid_count: ValidCount,
+        valid_unfit_count: ValidUnfitCount,
+        suspect_count: SuspectCount
+    ],
+    "Represents the history of cash acceptance events."
+);
+
+create_xfs_array!(
+    CashTypeAcceptanceHistoryList,
+    "cashTypeAcceptanceHistoryItems",
+    CashTypeAcceptanceHistory,
+    CASH_TYPE_HISTORY_LIST_LEN,
+    CASH_TYPE_HISTORY_DEFAULT,
+    "Represents a list of [CashTypeAcceptanceHistory] items."
+);

--- a/bnr-xfs/src/history/cash_type_recycle_history.rs
+++ b/bnr-xfs/src/history/cash_type_recycle_history.rs
@@ -1,0 +1,26 @@
+use crate::CashType;
+use crate::{create_xfs_array, create_xfs_struct};
+
+use super::StackedWhileRecyclerFullCount;
+
+pub const CASH_TYPE_RECYCLE_LIST_LEN: usize = 10;
+pub const CASH_TYPE_RECYCLE_DEFAULT: CashTypeRecycleHistoryItem = CashTypeRecycleHistoryItem::new();
+
+create_xfs_struct!(
+    CashTypeRecycleHistoryItem,
+    "cashTypeRecycleHistoryItem",
+    [
+        cash_type: CashType,
+        stacked_while_recycler_full_count: StackedWhileRecyclerFullCount
+    ],
+    "Represents a cash type recycle history item."
+);
+
+create_xfs_array!(
+    CashTypeRecycleHistoryItems,
+    "cashTypeRecycleHistoryItems",
+    CashTypeRecycleHistoryItem,
+    CASH_TYPE_RECYCLE_LIST_LEN,
+    CASH_TYPE_RECYCLE_DEFAULT,
+    "Represents a list of [CashTypeRecycleHistoryItem] items."
+);

--- a/bnr-xfs/src/history/counts.rs
+++ b/bnr-xfs/src/history/counts.rs
@@ -1,0 +1,207 @@
+use crate::create_xfs_i4;
+
+create_xfs_i4!(
+    InsertionStartCount,
+    "insertionStartCount",
+    "Represents the start count for bill insertion."
+);
+
+create_xfs_i4!(
+    InsertionRejectCount,
+    "insertionRejectCount",
+    "Represents the reject count for bill insertion."
+);
+
+create_xfs_i4!(
+    CancelRejectCount,
+    "cancelRejectCount",
+    "Represents the cancel reject count."
+);
+
+create_xfs_i4!(
+    UnknownCount,
+    "unknownCount",
+    "Represents the unknown count."
+);
+
+create_xfs_i4!(
+    UnknownRejectCount,
+    "unknownRejectCount",
+    "Represents the unknown reject count."
+);
+
+create_xfs_i4!(
+    ConfusionCount,
+    "confusionCount",
+    "Represents the confusion count."
+);
+
+create_xfs_i4!(
+    FitnessCount,
+    "fitnessCount",
+    "Represents the fitness count."
+);
+
+create_xfs_i4!(
+    FitnessRejectCount,
+    "fitnessRejectCount",
+    "Represents the fitness reject count."
+);
+
+create_xfs_i4!(ValidCount, "validCount", "Represents the valid count.");
+
+create_xfs_i4!(
+    ValidUnfitCount,
+    "validUnfitCount",
+    "Represents the valid unfit count."
+);
+
+create_xfs_i4!(
+    SuspectCount,
+    "suspectCount",
+    "Represents the suspect count."
+);
+
+create_xfs_i4!(
+    StainedCount,
+    "stainedCount",
+    "Represents the stained count."
+);
+
+create_xfs_i4!(
+    ConfigurationRejectCount,
+    "configurationRejectCount",
+    "Represents the configuration reject count."
+);
+
+create_xfs_i4!(
+    BillExtractedCount,
+    "billExtractedCount",
+    "Represents the bill extracted count."
+);
+
+create_xfs_i4!(
+    BillRolledBackCount,
+    "billRolledBackCount",
+    "Represents the bill rolled back count."
+);
+
+create_xfs_i4!(
+    CashInTransactionCount,
+    "cashInTransactionCount",
+    "Represents the cash in transaction count."
+);
+
+create_xfs_i4!(
+    TransportRejectCount,
+    "transportRejectCount",
+    "Represents the transport reject count."
+);
+
+create_xfs_i4!(
+    TransportEventCount,
+    "transportEventCount",
+    "Represents the transport event count."
+);
+
+create_xfs_i4!(
+    ExtractionRejectCount,
+    "extractionRejectCount",
+    "Represents the extraction reject count."
+);
+
+create_xfs_i4!(
+    RecognitionRejectCount,
+    "recognitionRejectCount",
+    "Represents the recognition reject count."
+);
+
+create_xfs_i4!(
+    PositioningFailedCount,
+    "positioningFailedCount",
+    "Represents the positioning failed count."
+);
+
+create_xfs_i4!(
+    SystemEventCount,
+    "systemEventCount",
+    "Represents the system event count."
+);
+
+create_xfs_i4!(
+    ForcedInCount,
+    "forcedInCount",
+    "Represents the forced in count."
+);
+
+create_xfs_i4!(
+    RemovedCount,
+    "removedCount",
+    "Represents the removed count."
+);
+
+create_xfs_i4!(
+    HeldBackCount,
+    "heldBackCount",
+    "Represents the held back count."
+);
+
+create_xfs_i4!(
+    TooThickCount,
+    "tooThickCount",
+    "Represents the too thick count."
+);
+
+create_xfs_i4!(
+    TooLongCount,
+    "tooLongCount",
+    "Represents the too long count."
+);
+
+create_xfs_i4!(
+    BadRoughShapeCount,
+    "badRoughShapeCount",
+    "Represents the bad rough shape count."
+);
+
+create_xfs_i4!(
+    BadShapeCount,
+    "badShapeCount",
+    "Represents the bad shape count."
+);
+
+create_xfs_i4!(
+    BadShapeRejectCount,
+    "badShapeRejectCount",
+    "Represents the bad shape reject count."
+);
+
+create_xfs_i4!(
+    StringDetectionCount,
+    "stringDetectionCount",
+    "Represents the string detection count."
+);
+
+create_xfs_i4!(
+    InletDetectionCount,
+    "inletDetectionCount",
+    "Represents the inlet detection count."
+);
+
+create_xfs_i4!(
+    SuperimposedCount,
+    "superimposedCount",
+    "Represents the superimposed count."
+);
+
+create_xfs_i4!(
+    OtherDenominationCount,
+    "otherDenominationCount",
+    "Represents the other denomination count."
+);
+
+create_xfs_i4!(
+    StackedWhileRecyclerFullCount,
+    "stackedWhileRecyclerFullCount",
+    "Represents the stacked while recycler full count."
+);

--- a/bnr-xfs/src/history/extraction_reject_details.rs
+++ b/bnr-xfs/src/history/extraction_reject_details.rs
@@ -1,0 +1,13 @@
+use crate::create_xfs_struct;
+
+use super::{SuperimposedCount, TooLongCount};
+
+create_xfs_struct!(
+    ExtractionRejectDetails,
+    "extractionRejectDetails",
+    [
+        too_long_count: TooLongCount,
+        superimposed_count: SuperimposedCount
+    ],
+    "Represents the details of extraction reject events."
+);

--- a/bnr-xfs/src/history/inlet_acceptance_history.rs
+++ b/bnr-xfs/src/history/inlet_acceptance_history.rs
@@ -1,0 +1,31 @@
+use crate::create_xfs_struct;
+use crate::ForgeryCount;
+
+use super::{
+    BillRolledBackCount, CancelRejectCount, CashInTransactionCount, ConfigurationRejectCount,
+    ConfusionCount, FitnessCount, InsertionRejectCount, InsertionStartCount, StainedCount,
+    SuspectCount, TransportRejectCount, UnknownRejectCount, ValidCount, ValidUnfitCount,
+};
+
+create_xfs_struct!(
+    InletAcceptanceHistory,
+    "inletAcceptanceHistory",
+    [
+        insertion_start_count: InsertionStartCount,
+        insertion_reject_count: InsertionRejectCount,
+        cancel_reject_count: CancelRejectCount,
+        unknown_reject_count: UnknownRejectCount,
+        confusion_count: ConfusionCount,
+        forgery_count: ForgeryCount,
+        fitness_count: FitnessCount,
+        valid_count: ValidCount,
+        valid_unfit_count: ValidUnfitCount,
+        suspect_count: SuspectCount,
+        stained_count: StainedCount,
+        configuration_reject_count: ConfigurationRejectCount,
+        bill_rolled_back_count: BillRolledBackCount,
+        cash_in_transaction_count: CashInTransactionCount,
+        transport_reject_count: TransportRejectCount
+    ],
+    "Represents inlet acceptance history."
+);

--- a/bnr-xfs/src/history/insertion_reject_details.rs
+++ b/bnr-xfs/src/history/insertion_reject_details.rs
@@ -1,0 +1,22 @@
+use crate::create_xfs_struct;
+
+use super::{
+    BadRoughShapeCount, BadShapeCount, ForcedInCount, HeldBackCount, InletDetectionCount,
+    RemovedCount, StringDetectionCount, TooThickCount,
+};
+
+create_xfs_struct!(
+    InsertionRejectDetails,
+    "insertionRejectDetails",
+    [
+        forced_in_count: ForcedInCount,
+        removed_count: RemovedCount,
+        held_back_count: HeldBackCount,
+        too_thick_count: TooThickCount,
+        bad_rough_shape_count: BadRoughShapeCount,
+        bad_shape_count: BadShapeCount,
+        string_detection_count: StringDetectionCount,
+        inlet_detection_count: InletDetectionCount
+    ],
+    "Represents details about inssertion reject events."
+);

--- a/bnr-xfs/src/history/loader_acceptance_history.rs
+++ b/bnr-xfs/src/history/loader_acceptance_history.rs
@@ -1,0 +1,21 @@
+use crate::create_xfs_struct;
+
+use super::{
+    BadShapeRejectCount, BillExtractedCount, ExtractionRejectCount, RecognitionRejectCount, Slots,
+    TransportRejectCount, TransportRejectDetails,
+};
+
+create_xfs_struct!(
+    LoaderAcceptanceHistory,
+    "loaderAcceptanceHistory",
+    [
+        bill_extracted_count: BillExtractedCount,
+        extraction_reject_count: ExtractionRejectCount,
+        transport_reject_count: TransportRejectCount,
+        transport_reject_details: TransportRejectDetails,
+        recognition_reject_count: RecognitionRejectCount,
+        bad_shape_reject_count: BadShapeRejectCount,
+        slots: Slots
+    ],
+    "Acceptance bills extracted from the loader unit."
+);

--- a/bnr-xfs/src/history/loader_slot_acceptance_history.rs
+++ b/bnr-xfs/src/history/loader_slot_acceptance_history.rs
@@ -1,0 +1,34 @@
+use crate::{create_xfs_array, create_xfs_i4, create_xfs_struct};
+
+use super::{
+    BillExtractedCount, ExtractionRejectDetails, OtherDenominationCount, RecognitionRejectDetails,
+    ValidUnfitCount,
+};
+
+pub const SLOT_HISTORY_LIST_LEN: usize = 4;
+pub const LOADER_SLOT_DEFAULT: LoaderSlotAcceptanceHistory = LoaderSlotAcceptanceHistory::new();
+
+create_xfs_i4!(SlotNumber, "slotNumber", "Represents the slot number.");
+
+create_xfs_struct!(
+    LoaderSlotAcceptanceHistory,
+    "loaderSlotAcceptanceHistory",
+    [
+        slot_number: SlotNumber,
+        bill_extracted_count: BillExtractedCount,
+        other_denomination_count: OtherDenominationCount,
+        valid_unfit_count: ValidUnfitCount,
+        extraction_reject_details: ExtractionRejectDetails,
+        recognition_reject_details: RecognitionRejectDetails
+    ],
+    "Represents the loader slot acceptance history."
+);
+
+create_xfs_array!(
+    Slots,
+    "slots",
+    LoaderSlotAcceptanceHistory,
+    SLOT_HISTORY_LIST_LEN,
+    LOADER_SLOT_DEFAULT,
+    "Represents a list of [LoaderSlotAcceptanceHistory] items."
+);

--- a/bnr-xfs/src/history/recognition_reject_details.rs
+++ b/bnr-xfs/src/history/recognition_reject_details.rs
@@ -1,0 +1,14 @@
+use crate::create_xfs_struct;
+use crate::ForgeryCount;
+
+use super::UnknownCount;
+
+create_xfs_struct!(
+    RecognitionRejectDetails,
+    "recognitionRejectDetails",
+    [
+        forgery_count: ForgeryCount,
+        unknown_count: UnknownCount
+    ],
+    "Represents the details of recognition reject events."
+);

--- a/bnr-xfs/src/history/transport_reject_details.rs
+++ b/bnr-xfs/src/history/transport_reject_details.rs
@@ -1,0 +1,14 @@
+use crate::create_xfs_struct;
+
+use super::{PositioningFailedCount, SystemEventCount, TransportEventCount};
+
+create_xfs_struct!(
+    TransportRejectDetails,
+    "transportRejectDetails",
+    [
+        positioning_failed_count: PositioningFailedCount,
+        transport_event_count: TransportEventCount,
+        system_event_count: SystemEventCount
+    ],
+    "Represents the details of transport reject events."
+);

--- a/bnr-xfs/src/lib.rs
+++ b/bnr-xfs/src/lib.rs
@@ -8,6 +8,7 @@ mod denominations;
 pub mod device_handle;
 mod dispense;
 mod error;
+mod history;
 mod intermediate_event;
 #[macro_use]
 mod macros;
@@ -23,6 +24,7 @@ pub use denominations::*;
 pub use device_handle::*;
 pub use dispense::*;
 pub use error::*;
+pub use history::*;
 pub use intermediate_event::*;
 pub use status::*;
 

--- a/bnr-xfs/src/macros.rs
+++ b/bnr-xfs/src/macros.rs
@@ -666,7 +666,15 @@ macro_rules! impl_xfs_struct {
             #[allow(clippy::needless_update)]
             fn try_from(val: &$crate::xfs::xfs_struct::XfsStruct) -> $crate::Result<Self> {
                 Ok(Self {
-                    $($field_name: val.find_member($field_ty::xfs_name())?.try_into()?,)*
+                    $(
+                        $field_name: match val.find_member($field_ty::xfs_name()) {
+                            Ok(m) => m.try_into()?,
+                            Err(_err) => {
+                                ::log::warn!("Missing member {} from {}", stringify!($field_name), stringify!($ty));
+                                $field_ty::new()
+                            }
+                        },
+                    )*
                     ..Default::default()
                 })
             }

--- a/bnr-xfs/src/xfs/method_call.rs
+++ b/bnr-xfs/src/xfs/method_call.rs
@@ -278,6 +278,8 @@ pub enum XfsMethodName {
     UpdateDenominations,
     #[serde(rename = "bnr.querybillsetids")]
     QueryBillsetIds,
+    #[serde(rename = "bnr.getbillacceptancehistory")]
+    GetBillAcceptanceHistory,
     // **NOTE**: `Occured` is not a typo here, it is a mispelling in the protocol message that we have to replicate
     #[serde(rename = "BnrListener.operationCompleteOccured")]
     OperationCompleteOccurred,
@@ -327,6 +329,7 @@ impl From<&XfsMethodName> for &'static str {
             XfsMethodName::QueryDenominations => "bnr.querydenominations",
             XfsMethodName::UpdateDenominations => "bnr.updatedenominations",
             XfsMethodName::QueryBillsetIds => "bnr.querybillsetids",
+            XfsMethodName::GetBillAcceptanceHistory => "bnr.getbillacceptancehistory",
             XfsMethodName::OperationCompleteOccurred => "BnrListener.operationCompleteOccured",
             XfsMethodName::IntermediateOccurred => "BnrListener.intermediateOccured",
             XfsMethodName::StatusOccurred => "BnrListener.statusOccured",
@@ -373,6 +376,7 @@ impl TryFrom<&str> for XfsMethodName {
             "bnr.querydenominations" => Ok(Self::QueryDenominations),
             "bnr.updatedenominations" => Ok(Self::UpdateDenominations),
             "bnr.querybillsetids" => Ok(Self::QueryBillsetIds),
+            "bnr.getbillacceptancehistory" => Ok(Self::GetBillAcceptanceHistory),
             "bnrlistener.operationcompleteoccured" => Ok(Self::OperationCompleteOccurred),
             "bnrlistener.intermediateoccured" => Ok(Self::IntermediateOccurred),
             "bnrlistener.statusoccured" => Ok(Self::StatusOccurred),

--- a/bnr-xfs/tests/e2e_tests/history.rs
+++ b/bnr-xfs/tests/e2e_tests/history.rs
@@ -1,0 +1,23 @@
+use bnr_xfs::{DeviceHandle, Result};
+
+use super::common;
+
+#[test]
+fn test_get_bill_acceptance_history() -> Result<()> {
+    let _lock = common::init();
+
+    let handle = DeviceHandle::open(None, None, None)?;
+
+    handle.close()?;
+
+    let date = handle.get_date_time()?;
+    if date.year() == 2001 {
+        handle.set_current_date_time()?;
+    }
+
+    let history = handle.get_bill_acceptance_history()?;
+
+    log::debug!("Bill acceptance history: {history}");
+
+    Ok(())
+}

--- a/bnr-xfs/tests/e2e_tests/mod.rs
+++ b/bnr-xfs/tests/e2e_tests/mod.rs
@@ -1,6 +1,7 @@
 mod cash;
 mod common;
 mod denominations;
+mod history;
 mod init;
 mod maintenance;
 mod status;


### PR DESCRIPTION
Adds the `DeviceHandle::get_bill_acceptance_history` method, and related types for parsing the XFS message returned by the method.

Adds helper macros to reduce boilerplate code when creating XFS types.

Simplifies some parsing for optional/potentially missing XFS struct members. Instead of erroring out on a missing member, log a warning, and return a default member.