### PR TITLE
bnr-xfs: add get bill dispense history method

### DIFF
--- a/bnr-xfs/src/capabilities.rs
+++ b/bnr-xfs/src/capabilities.rs
@@ -220,7 +220,7 @@ impl TryFrom<&XfsParams> for Capabilities {
 
     fn try_from(val: &XfsParams) -> Result<Self> {
         val.params()
-            .get(0)
+            .first()
             .ok_or(Error::Xfs(format!("Missing param: {val}")))?
             .inner()
             .value()

--- a/bnr-xfs/src/counts.rs
+++ b/bnr-xfs/src/counts.rs
@@ -259,3 +259,45 @@ create_xfs_i4!(
     "stackedWhileRecyclerFullCount",
     "Represents the stacked while recycler full count."
 );
+
+create_xfs_i4!(
+    DenominateAmountCount,
+    "denominateAmountCount",
+    "Represents the denominate amount count."
+);
+
+create_xfs_i4!(
+    AmountNotAvailableCount,
+    "amountNotAvailableCount",
+    "Represents the amount not available count."
+);
+
+create_xfs_i4!(
+    BillRequestedCount,
+    "billRequestedCount",
+    "Represents the bill requested count."
+);
+
+create_xfs_i4!(
+    BillNotAvailableCount,
+    "billNotAvailableCount",
+    "Represents the bill not available count."
+);
+
+create_xfs_i4!(
+    TooManyBillsCount,
+    "tooManyBillsCount",
+    "Represents the too many bills count."
+);
+
+create_xfs_i4!(
+    DirectFromLoaderCount,
+    "directFromLoaderCount",
+    "Represents the direct from loader count."
+);
+
+create_xfs_i4!(
+    DispenseAmountCount,
+    "dispenseAmountCount",
+    "Represents the dispense amount count."
+);

--- a/bnr-xfs/src/currency/code.rs
+++ b/bnr-xfs/src/currency/code.rs
@@ -138,6 +138,6 @@ impl TryFrom<XfsMember> for CurrencyCode {
 
 impl fmt::Display for CurrencyCode {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, r#""{}""#, self.0)
+        write!(f, "{}", self.0)
     }
 }

--- a/bnr-xfs/src/device_handle.rs
+++ b/bnr-xfs/src/device_handle.rs
@@ -11,7 +11,7 @@ use crate::currency::{CashOrder, CurrencyCode};
 use crate::denominations::BillsetIdList;
 use crate::denominations::DenominationList;
 use crate::dispense::DispenseRequest;
-use crate::history::BillAcceptanceHistory;
+use crate::history::{BillAcceptanceHistory, BillDispenseHistory};
 use crate::status::CdrStatus;
 use crate::xfs;
 use crate::{Error, Result};
@@ -507,6 +507,11 @@ impl DeviceHandle {
     /// Gets the BNR [BillAcceptanceHistory].
     pub fn get_bill_acceptance_history(&self) -> Result<BillAcceptanceHistory> {
         self.get_bill_acceptance_history_inner()
+    }
+
+    /// Gets the BNR [BillDispenseHistory].
+    pub fn get_bill_dispense_history(&self) -> Result<BillDispenseHistory> {
+        self.get_bill_dispense_history_inner()
     }
 
     /// Gets a reference to the [UsbDeviceHandle].

--- a/bnr-xfs/src/device_handle/inner.rs
+++ b/bnr-xfs/src/device_handle/inner.rs
@@ -208,12 +208,12 @@ impl DeviceHandle {
                 -1 => {
                     let err_msg = format!("async response: missing event result: {msg}");
                     log::error!("{err_msg}");
-                    Err(Error::Xfs(err_msg.into()))
+                    Err(Error::Xfs(err_msg))
                 }
                 _ => {
                     let err_msg = format!("async response: call failed: {msg}");
                     log::error!("{err_msg}");
-                    Err(Error::Xfs(err_msg.into()))
+                    Err(Error::Xfs(err_msg))
                 }
             }
         } else {

--- a/bnr-xfs/src/device_handle/inner.rs
+++ b/bnr-xfs/src/device_handle/inner.rs
@@ -718,4 +718,12 @@ impl DeviceHandle {
         usb.write_call(&call)?;
         usb.read_response(call.name()?)?.try_into()
     }
+
+    pub(crate) fn get_bill_dispense_history_inner(&self) -> Result<BillDispenseHistory> {
+        let call = XfsMethodCall::create(XfsMethodName::GetBillDispenseHistory, []);
+        let usb = self.usb();
+
+        usb.write_call(&call)?;
+        usb.read_response(call.name()?)?.try_into()
+    }
 }

--- a/bnr-xfs/src/history.rs
+++ b/bnr-xfs/src/history.rs
@@ -1,5 +1,7 @@
 mod bill_acceptance_history;
+mod bill_dispense_history;
 mod cash_type_acceptance_history;
+mod cash_type_dispense_history;
 mod cash_type_recycle_history;
 mod extraction_reject_details;
 mod inlet_acceptance_history;
@@ -10,7 +12,9 @@ mod recognition_reject_details;
 mod transport_reject_details;
 
 pub use bill_acceptance_history::*;
+pub use bill_dispense_history::*;
 pub use cash_type_acceptance_history::*;
+pub use cash_type_dispense_history::*;
 pub use cash_type_recycle_history::*;
 pub use extraction_reject_details::*;
 pub use inlet_acceptance_history::*;

--- a/bnr-xfs/src/history/bill_dispense_history.rs
+++ b/bnr-xfs/src/history/bill_dispense_history.rs
@@ -1,0 +1,48 @@
+use crate::create_xfs_struct;
+use crate::xfs::method_response::XfsMethodResponse;
+use crate::{
+    AmountNotAvailableCount, BillNotAvailableCount, BillRequestedCount,
+    CashTypeDispenseHistoryItems, DenominateAmountCount, DirectFromLoaderCount,
+    DispenseAmountCount, Error, Result, TooManyBillsCount,
+};
+
+create_xfs_struct!(
+    BillDispenseHistory,
+    "billDispenseHistory",
+    [
+        denominate_amount_count: DenominateAmountCount,
+        amount_not_available_count: AmountNotAvailableCount,
+        bill_requested_count: BillRequestedCount,
+        bill_not_available_count: BillNotAvailableCount,
+        too_many_bills_count: TooManyBillsCount,
+        direct_from_loader_count: DirectFromLoaderCount,
+        dispense_amount_count: DispenseAmountCount,
+        cash_type_dispense_history_items: CashTypeDispenseHistoryItems
+    ],
+    "Represents the bill dispense history of the BNR device."
+);
+
+impl TryFrom<&XfsMethodResponse> for BillDispenseHistory {
+    type Error = Error;
+
+    fn try_from(val: &XfsMethodResponse) -> Result<Self> {
+        val.as_params()?
+            .params()
+            .iter()
+            .map(|m| m.inner())
+            .find(|m| m.value().xfs_struct().is_some())
+            .ok_or(Error::Xfs(format!(
+                "Expected BillDispenseHistory XfsMethodResponse, have: {val}"
+            )))?
+            .value()
+            .try_into()
+    }
+}
+
+impl TryFrom<XfsMethodResponse> for BillDispenseHistory {
+    type Error = Error;
+
+    fn try_from(val: XfsMethodResponse) -> Result<Self> {
+        (&val).try_into()
+    }
+}

--- a/bnr-xfs/src/history/cash_type_dispense_history.rs
+++ b/bnr-xfs/src/history/cash_type_dispense_history.rs
@@ -1,0 +1,25 @@
+use crate::{create_xfs_array, create_xfs_struct};
+use crate::{BillNotAvailableCount, BillRequestedCount, CashType};
+
+const CASH_TYPE_HISTORY_DEFAULT: CashTypeDispenseHistory = CashTypeDispenseHistory::new();
+const CASH_TYPE_HISTORY_LEN: usize = 61;
+
+create_xfs_struct!(
+    CashTypeDispenseHistory,
+    "cashTypeDispenseHistory",
+    [
+        cash_type: CashType,
+        bill_requested_count: BillRequestedCount,
+        bill_not_available_count: BillNotAvailableCount
+    ],
+    "Represents the dispense history of each [CashType]"
+);
+
+create_xfs_array!(
+    CashTypeDispenseHistoryItems,
+    "cashTypeDispenseHistoryItems",
+    CashTypeDispenseHistory,
+    CASH_TYPE_HISTORY_LEN,
+    CASH_TYPE_HISTORY_DEFAULT,
+    "Represents a list of [CashTypeDispenseHistory] items."
+);

--- a/bnr-xfs/src/xfs/fault.rs
+++ b/bnr-xfs/src/xfs/fault.rs
@@ -47,7 +47,7 @@ impl XfsFault {
     /// Gets the fault code value.
     pub fn code(&self) -> i32 {
         match self.value.xfs_struct() {
-            Some(fc) => match fc.members().get(0) {
+            Some(fc) => match fc.members().first() {
                 Some(m) => match m.inner().value().i4() {
                     Some(val) => *val,
                     None => 0,

--- a/bnr-xfs/src/xfs/method_call.rs
+++ b/bnr-xfs/src/xfs/method_call.rs
@@ -280,6 +280,8 @@ pub enum XfsMethodName {
     QueryBillsetIds,
     #[serde(rename = "bnr.getbillacceptancehistory")]
     GetBillAcceptanceHistory,
+    #[serde(rename = "bnr.getbilldispensehistory")]
+    GetBillDispenseHistory,
     // **NOTE**: `Occured` is not a typo here, it is a mispelling in the protocol message that we have to replicate
     #[serde(rename = "BnrListener.operationCompleteOccured")]
     OperationCompleteOccurred,
@@ -330,6 +332,7 @@ impl From<&XfsMethodName> for &'static str {
             XfsMethodName::UpdateDenominations => "bnr.updatedenominations",
             XfsMethodName::QueryBillsetIds => "bnr.querybillsetids",
             XfsMethodName::GetBillAcceptanceHistory => "bnr.getbillacceptancehistory",
+            XfsMethodName::GetBillDispenseHistory => "bnr.getbilldispensehistory",
             XfsMethodName::OperationCompleteOccurred => "BnrListener.operationCompleteOccured",
             XfsMethodName::IntermediateOccurred => "BnrListener.intermediateOccured",
             XfsMethodName::StatusOccurred => "BnrListener.statusOccured",
@@ -377,6 +380,7 @@ impl TryFrom<&str> for XfsMethodName {
             "bnr.updatedenominations" => Ok(Self::UpdateDenominations),
             "bnr.querybillsetids" => Ok(Self::QueryBillsetIds),
             "bnr.getbillacceptancehistory" => Ok(Self::GetBillAcceptanceHistory),
+            "bnr.getbilldispensehistory" => Ok(Self::GetBillDispenseHistory),
             "bnrlistener.operationcompleteoccured" => Ok(Self::OperationCompleteOccurred),
             "bnrlistener.intermediateoccured" => Ok(Self::IntermediateOccurred),
             "bnrlistener.statusoccured" => Ok(Self::StatusOccurred),

--- a/bnr-xfs/tests/e2e_tests/history.rs
+++ b/bnr-xfs/tests/e2e_tests/history.rs
@@ -21,3 +21,23 @@ fn test_get_bill_acceptance_history() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_get_bill_dispense_history() -> Result<()> {
+    let _lock = common::init();
+
+    let handle = DeviceHandle::open(None, None, None)?;
+
+    handle.close()?;
+
+    let date = handle.get_date_time()?;
+    if date.year() == 2001 {
+        handle.set_current_date_time()?;
+    }
+
+    let history = handle.get_bill_dispense_history()?;
+
+    log::debug!("Bill dispense history: {history}");
+
+    Ok(())
+}


### PR DESCRIPTION
Adds XFS types for making the GetBillDispenseHistory call.

Adds the `DeviceHandle::get_bill_dispense_history` method to get the history of bill dispense events from a BNR device.

Minor linter fixes.