### PR TITLE
bnr-xfs: add get failure history method call

### DIFF
--- a/bnr-xfs/src/counts.rs
+++ b/bnr-xfs/src/counts.rs
@@ -301,3 +301,135 @@ create_xfs_i4!(
     "dispenseAmountCount",
     "Represents the dispense amount count."
 );
+
+create_xfs_i4!(
+    HardwareFailureCount,
+    "hardwareFailureCount",
+    "Represents the hardware failure count."
+);
+
+create_xfs_i4!(
+    HardwareFailureWithBillStoppedCount,
+    "hardwareFailureWithBillStoppedCount",
+    "Represents the hardware failure with bill stopped count."
+);
+
+create_xfs_i4!(
+    OperationalDegradedCount,
+    "operationalDegradedCount",
+    "Represents the operational degraded count."
+);
+
+create_xfs_i4!(
+    BillJamCount,
+    "billJamCount",
+    "Represents the bill jam count."
+);
+
+create_xfs_i4!(
+    EnvironmentErrorCount,
+    "environmentErrorCount",
+    "Represents the environment error count."
+);
+
+create_xfs_i4!(
+    BillErrorCount,
+    "billErrorCount",
+    "Represents the bill error count."
+);
+
+create_xfs_i4!(
+    TransportErrorCount,
+    "transportErrorCount",
+    "Represents the transport error count."
+);
+
+create_xfs_i4!(
+    BillTooShortInBottomTransportBwCount,
+    "billTooShortInBottomTransportBwCount",
+    "Represents the bill too short in bottom transport bw count."
+);
+
+create_xfs_i4!(
+    BillTooLongInBottomTransportBwCount,
+    "billTooLongInBottomTransportBwCount",
+    "Represents the bill too long in bottom transport bw count."
+);
+
+create_xfs_i4!(
+    BillTooShortInSpineFwCount,
+    "billTooShortInSpineFwCount",
+    "Represents the bill too short in spine fw count."
+);
+
+create_xfs_i4!(
+    BillTooLongInSpineFwCount,
+    "billTooLongInSpineFwCount",
+    "Represents the bill too long in spine fw count."
+);
+
+create_xfs_i4!(
+    MissingModuleCount,
+    "missingModuleCount",
+    "Represents the missile module count."
+);
+
+create_xfs_i4!(
+    ConfigurationErrorCount,
+    "configurationErrorCount",
+    "Represents the configuration error count."
+);
+
+create_xfs_i4!(
+    IncompatibleSoftwareCount,
+    "incompatibleSoftwareCount",
+    "Represents the incompatible software count."
+);
+
+create_xfs_i4!(
+    ResetWithCoverOpenCount,
+    "resetWithCoverOpenCount",
+    "Represents the reset with cover open count."
+);
+
+create_xfs_i4!(
+    ResetWithInterlockOpenCount,
+    "resetWithInterlockOpenCount",
+    "Represents the reset with interlock open count."
+);
+
+create_xfs_i4!(
+    PositionerCount,
+    "positionerCount",
+    "Represents the positioner count."
+);
+
+create_xfs_i4!(
+    RecognitionSystemCount,
+    "recognitionSystemCount",
+    "Represents the recognition system count."
+);
+
+create_xfs_i4!(
+    BottomTransportCount,
+    "bottomTransportCount",
+    "Represents the bottom transport count."
+);
+
+create_xfs_i4!(
+    BundlerCount,
+    "bundlerCount",
+    "Represents the bundler count."
+);
+
+create_xfs_i4!(ModuleCount, "moduleCount", "Represents the module count.");
+
+create_xfs_i4!(
+    InterfaceCount,
+    "interfaceCount",
+    "Represents the interface count."
+);
+
+create_xfs_i4!(SpineCount, "spineCount", "Represents the spine count.");
+
+create_xfs_i4!(UnnamedCount, "", "Represents an unnamed count.");

--- a/bnr-xfs/src/device_handle.rs
+++ b/bnr-xfs/src/device_handle.rs
@@ -11,7 +11,7 @@ use crate::currency::{CashOrder, CurrencyCode};
 use crate::denominations::BillsetIdList;
 use crate::denominations::DenominationList;
 use crate::dispense::DispenseRequest;
-use crate::history::{BillAcceptanceHistory, BillDispenseHistory};
+use crate::history::{BillAcceptanceHistory, BillDispenseHistory, SystemFailureHistory};
 use crate::status::CdrStatus;
 use crate::xfs;
 use crate::{Error, Result};
@@ -512,6 +512,11 @@ impl DeviceHandle {
     /// Gets the BNR [BillDispenseHistory].
     pub fn get_bill_dispense_history(&self) -> Result<BillDispenseHistory> {
         self.get_bill_dispense_history_inner()
+    }
+
+    /// Gets the BNR [SystemFailureHistory].
+    pub fn get_failure_history(&self) -> Result<SystemFailureHistory> {
+        self.get_failure_history_inner()
     }
 
     /// Gets a reference to the [UsbDeviceHandle].

--- a/bnr-xfs/src/device_handle/inner.rs
+++ b/bnr-xfs/src/device_handle/inner.rs
@@ -726,4 +726,12 @@ impl DeviceHandle {
         usb.write_call(&call)?;
         usb.read_response(call.name()?)?.try_into()
     }
+
+    pub(crate) fn get_failure_history_inner(&self) -> Result<SystemFailureHistory> {
+        let call = XfsMethodCall::create(XfsMethodName::GetFailureHistory, []);
+        let usb = self.usb();
+
+        usb.write_call(&call)?;
+        usb.read_response(call.name()?)?.try_into()
+    }
 }

--- a/bnr-xfs/src/history.rs
+++ b/bnr-xfs/src/history.rs
@@ -9,6 +9,7 @@ mod insertion_reject_details;
 mod loader_acceptance_history;
 mod loader_slot_acceptance_history;
 mod recognition_reject_details;
+mod system_failure_history;
 mod transport_reject_details;
 
 pub use bill_acceptance_history::*;
@@ -22,4 +23,5 @@ pub use insertion_reject_details::*;
 pub use loader_acceptance_history::*;
 pub use loader_slot_acceptance_history::*;
 pub use recognition_reject_details::*;
+pub use system_failure_history::*;
 pub use transport_reject_details::*;

--- a/bnr-xfs/src/history/system_failure_history.rs
+++ b/bnr-xfs/src/history/system_failure_history.rs
@@ -1,0 +1,337 @@
+use crate::xfs::method_response::XfsMethodResponse;
+use crate::{create_xfs_array, create_xfs_struct};
+use crate::{
+    BillErrorCount, BillJamCount, BillTooLongInBottomTransportBwCount, BillTooLongInSpineFwCount,
+    BillTooShortInBottomTransportBwCount, BillTooShortInSpineFwCount, BottomTransportCount,
+    BundlerCount, ConfigurationErrorCount, EnvironmentErrorCount, Error, HardwareFailureCount,
+    HardwareFailureWithBillStoppedCount, IncompatibleSoftwareCount, InterfaceCount,
+    MissingModuleCount, ModuleCount, OperationalDegradedCount, PositionerCount,
+    RecognitionSystemCount, ResetWithCoverOpenCount, ResetWithInterlockOpenCount, Result,
+    SpineCount, TransportErrorCount, UnnamedCount,
+};
+
+const BILL_ENDING_COUNTERS_LEN: usize = 4;
+const INCIDENT_START_COUNTERS_LEN: usize = 25;
+
+const UNNAMED_COUNT_DEFAULT: UnnamedCount = UnnamedCount::new();
+
+const MODULE_COUNT_LIST_LEN: usize = 10;
+const MODULE_COUNT_DEFAULT: ModuleCount = ModuleCount::new();
+
+const INTERFACE_COUNT_LIST_LEN: usize = 10;
+const INTERFACE_COUNT_DEFAULT: InterfaceCount = InterfaceCount::new();
+
+create_xfs_struct!(
+    MainModuleSectionCounters,
+    "mainModuleSectionCounters",
+    [
+        positioner_count: PositionerCount,
+        recognition_system_count: RecognitionSystemCount,
+        bottom_transport_count: BottomTransportCount,
+        bundler_count: BundlerCount
+    ],
+    "Represents the main module section counters."
+);
+
+create_xfs_struct!(
+    IncidentStartSectionCounters,
+    "incidentStartSectionCounters",
+    [
+        positioner_count: PositionerCount,
+        recognition_system_count: RecognitionSystemCount,
+        bottom_transport_count: BottomTransportCount,
+        bundler_count: BundlerCount,
+        spine_count: SpineCount,
+        module_counts: ModuleCountList,
+        interface_counts: InterfaceCountList
+    ],
+    "Represents the incident start section counters."
+);
+
+create_xfs_array!(
+    ModuleCountList,
+    "moduleCountList",
+    ModuleCount,
+    MODULE_COUNT_LIST_LEN,
+    MODULE_COUNT_DEFAULT,
+    "Represents a list of module count items."
+);
+
+create_xfs_array!(
+    InterfaceCountList,
+    "interfaceCountList",
+    InterfaceCount,
+    INTERFACE_COUNT_LIST_LEN,
+    INTERFACE_COUNT_DEFAULT,
+    "Represents a list of interface count items."
+);
+
+create_xfs_array!(
+    BillEndingInMMSectionCounters,
+    "billEndingInMMSectionCounters",
+    UnnamedCount,
+    BILL_ENDING_COUNTERS_LEN,
+    UNNAMED_COUNT_DEFAULT,
+    "Represents a list of bill ending in main module section count items."
+);
+
+create_xfs_array!(
+    IncidentStartSectionCountersList,
+    "incidentStartSectionCounters",
+    UnnamedCount,
+    INCIDENT_START_COUNTERS_LEN,
+    UNNAMED_COUNT_DEFAULT,
+    "Represents a list of incident start section count items."
+);
+
+create_xfs_struct!(
+    PerSectionHistoryInternal,
+    "perSectionHistory",
+    [
+        bill_ending_in_mm_section_counters: BillEndingInMMSectionCounters,
+        incident_start_section: IncidentStartSectionCountersList
+    ],
+    "Represents the internal XFS representation of per-section history."
+);
+
+create_xfs_struct!(
+    PerSectionHistory,
+    "perSectionHistory",
+    [
+        bill_ending_in_mm_section_counters: MainModuleSectionCounters,
+        incident_start_section: IncidentStartSectionCounters
+    ],
+    "Represents the internal XFS representation of per-section history."
+);
+
+impl From<&BillEndingInMMSectionCounters> for MainModuleSectionCounters {
+    fn from(val: &BillEndingInMMSectionCounters) -> Self {
+        let items = val.items();
+        Self {
+            positioner_count: items
+                .first()
+                .cloned()
+                .unwrap_or(UnnamedCount::new())
+                .inner()
+                .into(),
+            recognition_system_count: items
+                .get(1)
+                .cloned()
+                .unwrap_or(UnnamedCount::new())
+                .inner()
+                .into(),
+            bottom_transport_count: items
+                .get(2)
+                .cloned()
+                .unwrap_or(UnnamedCount::new())
+                .inner()
+                .into(),
+            bundler_count: items
+                .get(3)
+                .cloned()
+                .unwrap_or(UnnamedCount::new())
+                .inner()
+                .into(),
+        }
+    }
+}
+
+impl From<BillEndingInMMSectionCounters> for MainModuleSectionCounters {
+    fn from(val: BillEndingInMMSectionCounters) -> Self {
+        (&val).into()
+    }
+}
+
+impl From<&IncidentStartSectionCountersList> for IncidentStartSectionCounters {
+    fn from(val: &IncidentStartSectionCountersList) -> Self {
+        let items = val.items();
+        Self {
+            positioner_count: items
+                .first()
+                .cloned()
+                .unwrap_or(UnnamedCount::new())
+                .inner()
+                .into(),
+            recognition_system_count: items
+                .get(1)
+                .cloned()
+                .unwrap_or(UnnamedCount::new())
+                .inner()
+                .into(),
+            bottom_transport_count: items
+                .get(2)
+                .cloned()
+                .unwrap_or(UnnamedCount::new())
+                .inner()
+                .into(),
+            bundler_count: items
+                .get(3)
+                .cloned()
+                .unwrap_or(UnnamedCount::new())
+                .inner()
+                .into(),
+            spine_count: items
+                .get(4)
+                .cloned()
+                .unwrap_or(UnnamedCount::new())
+                .inner()
+                .into(),
+            module_counts: ModuleCountList::new().with_items(
+                items
+                    .iter()
+                    .skip(5)
+                    .take(10)
+                    .map(|i| ModuleCount::from(i.inner()))
+                    .collect::<Vec<ModuleCount>>()
+                    .as_ref(),
+            ),
+            interface_counts: InterfaceCountList::new().with_items(
+                items
+                    .iter()
+                    .skip(15)
+                    .take(10)
+                    .map(|i| InterfaceCount::from(i.inner()))
+                    .collect::<Vec<InterfaceCount>>()
+                    .as_ref(),
+            ),
+        }
+    }
+}
+
+impl From<IncidentStartSectionCountersList> for IncidentStartSectionCounters {
+    fn from(val: IncidentStartSectionCountersList) -> Self {
+        (&val).into()
+    }
+}
+
+impl From<&PerSectionHistoryInternal> for PerSectionHistory {
+    fn from(val: &PerSectionHistoryInternal) -> Self {
+        Self {
+            bill_ending_in_mm_section_counters: val.bill_ending_in_mm_section_counters().into(),
+            incident_start_section: val.incident_start_section().into(),
+        }
+    }
+}
+
+impl From<PerSectionHistoryInternal> for PerSectionHistory {
+    fn from(val: PerSectionHistoryInternal) -> Self {
+        (&val).into()
+    }
+}
+
+create_xfs_struct!(
+    SystemFailureHistory,
+    "systemFailureHistory",
+    [
+        hardware_failure_count: HardwareFailureCount,
+        hardware_failure_with_bill_stopped_count: HardwareFailureWithBillStoppedCount,
+        operational_degraded_count: OperationalDegradedCount,
+        bill_jam_count: BillJamCount,
+        environment_error_count: EnvironmentErrorCount,
+        bill_error_count: BillErrorCount,
+        transport_error_count: TransportErrorCount,
+        bill_too_short_in_bottom_transport_bw_count: BillTooShortInBottomTransportBwCount,
+        bill_too_long_in_bottom_transport_bw_count: BillTooLongInBottomTransportBwCount,
+        bill_too_short_in_spine_fw_count: BillTooShortInSpineFwCount,
+        bill_too_long_in_spine_fw_count: BillTooLongInSpineFwCount,
+        missing_module_count: MissingModuleCount,
+        configuration_error_count: ConfigurationErrorCount,
+        incompatible_software_count: IncompatibleSoftwareCount,
+        reset_with_cover_open_count: ResetWithCoverOpenCount,
+        reset_with_interlock_open_count: ResetWithInterlockOpenCount,
+        per_section_history: PerSectionHistory
+    ],
+    "Represents the history of system failure events."
+);
+
+create_xfs_struct!(
+    SystemFailureHistoryInternal,
+    "systemFailureHistory",
+    [
+        hardware_failure_count: HardwareFailureCount,
+        hardware_failure_with_bill_stopped_count: HardwareFailureWithBillStoppedCount,
+        operational_degraded_count: OperationalDegradedCount,
+        bill_jam_count: BillJamCount,
+        environment_error_count: EnvironmentErrorCount,
+        bill_error_count: BillErrorCount,
+        transport_error_count: TransportErrorCount,
+        bill_too_short_in_bottom_transport_bw_count: BillTooShortInBottomTransportBwCount,
+        bill_too_long_in_bottom_transport_bw_count: BillTooLongInBottomTransportBwCount,
+        bill_too_short_in_spine_fw_count: BillTooShortInSpineFwCount,
+        bill_too_long_in_spine_fw_count: BillTooLongInSpineFwCount,
+        missing_module_count: MissingModuleCount,
+        configuration_error_count: ConfigurationErrorCount,
+        incompatible_software_count: IncompatibleSoftwareCount,
+        reset_with_cover_open_count: ResetWithCoverOpenCount,
+        reset_with_interlock_open_count: ResetWithInterlockOpenCount,
+        per_section_history: PerSectionHistoryInternal
+    ],
+    "Alternative internal representation the history of system failure events."
+);
+
+impl From<&SystemFailureHistoryInternal> for SystemFailureHistory {
+    fn from(val: &SystemFailureHistoryInternal) -> Self {
+        Self {
+            hardware_failure_count: val.hardware_failure_count,
+            hardware_failure_with_bill_stopped_count: val.hardware_failure_with_bill_stopped_count,
+            operational_degraded_count: val.operational_degraded_count,
+            bill_jam_count: val.bill_jam_count,
+            environment_error_count: val.environment_error_count,
+            bill_error_count: val.bill_error_count,
+            transport_error_count: val.transport_error_count,
+            bill_too_short_in_bottom_transport_bw_count: val
+                .bill_too_short_in_bottom_transport_bw_count,
+            bill_too_long_in_bottom_transport_bw_count: val
+                .bill_too_long_in_bottom_transport_bw_count,
+            bill_too_short_in_spine_fw_count: val.bill_too_short_in_spine_fw_count,
+            bill_too_long_in_spine_fw_count: val.bill_too_long_in_spine_fw_count,
+            missing_module_count: val.missing_module_count,
+            configuration_error_count: val.configuration_error_count,
+            incompatible_software_count: val.incompatible_software_count,
+            reset_with_cover_open_count: val.reset_with_cover_open_count,
+            reset_with_interlock_open_count: val.reset_with_interlock_open_count,
+            per_section_history: val.per_section_history().into(),
+        }
+    }
+}
+
+impl From<SystemFailureHistoryInternal> for SystemFailureHistory {
+    fn from(val: SystemFailureHistoryInternal) -> Self {
+        (&val).into()
+    }
+}
+
+impl TryFrom<&XfsMethodResponse> for SystemFailureHistory {
+    type Error = Error;
+
+    fn try_from(val: &XfsMethodResponse) -> Result<Self> {
+        let xfs_struct = val
+            .as_params()?
+            .params()
+            .iter()
+            .map(|m| m.inner())
+            .find(|m| m.value().xfs_struct().is_some())
+            .ok_or(Error::Xfs(format!(
+                "Expected SystemFailureHistory XfsMethodResponse, have: {val}"
+            )))?
+            .value();
+
+        match SystemFailureHistory::try_from(xfs_struct) {
+            Ok(ret) => Ok(ret),
+            Err(err) => {
+                log::warn!("Error parsing SystemFailureHistory: {err}");
+                log::debug!("Trying SystemFailureHistoryInternal representation");
+
+                Ok(SystemFailureHistoryInternal::try_from(xfs_struct)?.into())
+            }
+        }
+    }
+}
+
+impl TryFrom<XfsMethodResponse> for SystemFailureHistory {
+    type Error = Error;
+
+    fn try_from(val: XfsMethodResponse) -> Result<Self> {
+        (&val).try_into()
+    }
+}

--- a/bnr-xfs/src/xfs/method_call.rs
+++ b/bnr-xfs/src/xfs/method_call.rs
@@ -282,6 +282,8 @@ pub enum XfsMethodName {
     GetBillAcceptanceHistory,
     #[serde(rename = "bnr.getbilldispensehistory")]
     GetBillDispenseHistory,
+    #[serde(rename = "bnr.getfailurehistory")]
+    GetFailureHistory,
     // **NOTE**: `Occured` is not a typo here, it is a mispelling in the protocol message that we have to replicate
     #[serde(rename = "BnrListener.operationCompleteOccured")]
     OperationCompleteOccurred,
@@ -333,6 +335,7 @@ impl From<&XfsMethodName> for &'static str {
             XfsMethodName::QueryBillsetIds => "bnr.querybillsetids",
             XfsMethodName::GetBillAcceptanceHistory => "bnr.getbillacceptancehistory",
             XfsMethodName::GetBillDispenseHistory => "bnr.getbilldispensehistory",
+            XfsMethodName::GetFailureHistory => "bnr.getfailurehistory",
             XfsMethodName::OperationCompleteOccurred => "BnrListener.operationCompleteOccured",
             XfsMethodName::IntermediateOccurred => "BnrListener.intermediateOccured",
             XfsMethodName::StatusOccurred => "BnrListener.statusOccured",
@@ -381,6 +384,7 @@ impl TryFrom<&str> for XfsMethodName {
             "bnr.querybillsetids" => Ok(Self::QueryBillsetIds),
             "bnr.getbillacceptancehistory" => Ok(Self::GetBillAcceptanceHistory),
             "bnr.getbilldispensehistory" => Ok(Self::GetBillDispenseHistory),
+            "bnr.getfailurehistory" => Ok(Self::GetFailureHistory),
             "bnrlistener.operationcompleteoccured" => Ok(Self::OperationCompleteOccurred),
             "bnrlistener.intermediateoccured" => Ok(Self::IntermediateOccurred),
             "bnrlistener.statusoccured" => Ok(Self::StatusOccurred),

--- a/bnr-xfs/tests/e2e_tests/history.rs
+++ b/bnr-xfs/tests/e2e_tests/history.rs
@@ -41,3 +41,23 @@ fn test_get_bill_dispense_history() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_get_failure_history() -> Result<()> {
+    let _lock = common::init();
+
+    let handle = DeviceHandle::open(None, None, None)?;
+
+    handle.close()?;
+
+    let date = handle.get_date_time()?;
+    if date.year() == 2001 {
+        handle.set_current_date_time()?;
+    }
+
+    let history = handle.get_failure_history()?;
+
+    log::debug!("System failure history: {history}");
+
+    Ok(())
+}


### PR DESCRIPTION
Adds the `DeviceHandle::get_failure_history` method call to get the history of system failure events.