### PR TITLE
bnr-xfs: add get restart history call

### DIFF
--- a/bnr-xfs/src/counts.rs
+++ b/bnr-xfs/src/counts.rs
@@ -433,3 +433,63 @@ create_xfs_i4!(
 create_xfs_i4!(SpineCount, "spineCount", "Represents the spine count.");
 
 create_xfs_i4!(UnnamedCount, "", "Represents an unnamed count.");
+
+create_xfs_i4!(
+    PowerUpCount,
+    "powerUpCount",
+    "Represents the power up count."
+);
+
+create_xfs_i4!(
+    PowerDownWithBillStoppedCount,
+    "powerDownWithBillStoppedCount",
+    "Represents the power down with bill stopped count."
+);
+
+create_xfs_i4!(
+    InternalResetCount,
+    "internalResetCount",
+    "Represents the internal reset count."
+);
+
+create_xfs_i4!(
+    InternalResetWithBillStoppedCount,
+    "internalResetWithBillStoppedCount",
+    "Represents the internal reset with bill stopped count."
+);
+
+create_xfs_i4!(
+    SystemOpeningCount,
+    "systemOpeningCount",
+    "Represents the system opening count."
+);
+
+create_xfs_i4!(
+    WithBillStoppedCount,
+    "withBillStoppedCount",
+    "Represents the with bill stopped count."
+);
+
+create_xfs_i4!(
+    CashModulesLockCount,
+    "cashModulesLockCount",
+    "Represents the cash modules locked count."
+);
+
+create_xfs_i4!(
+    BillIntakeCoverCount,
+    "billIntakeCoverCount",
+    "Represents the bill intake cover count."
+);
+
+create_xfs_i4!(
+    RecognitionSensorCoverCount,
+    "RecognitionSensorCoverCount",
+    "Represents the recognition sensor cover count."
+);
+
+create_xfs_i4!(
+    SpineCoverCount,
+    "spineCoverCount",
+    "Represents the spine cover count."
+);

--- a/bnr-xfs/src/device_handle.rs
+++ b/bnr-xfs/src/device_handle.rs
@@ -11,7 +11,9 @@ use crate::currency::{CashOrder, CurrencyCode};
 use crate::denominations::BillsetIdList;
 use crate::denominations::DenominationList;
 use crate::dispense::DispenseRequest;
-use crate::history::{BillAcceptanceHistory, BillDispenseHistory, SystemFailureHistory};
+use crate::history::{
+    BillAcceptanceHistory, BillDispenseHistory, SystemFailureHistory, SystemRestartHistory,
+};
 use crate::status::CdrStatus;
 use crate::xfs;
 use crate::{Error, Result};
@@ -517,6 +519,11 @@ impl DeviceHandle {
     /// Gets the BNR [SystemFailureHistory].
     pub fn get_failure_history(&self) -> Result<SystemFailureHistory> {
         self.get_failure_history_inner()
+    }
+
+    /// Gets the BNR [SystemRestartHistory].
+    pub fn get_restart_history(&self) -> Result<SystemRestartHistory> {
+        self.get_restart_history_inner()
     }
 
     /// Gets a reference to the [UsbDeviceHandle].

--- a/bnr-xfs/src/device_handle/inner.rs
+++ b/bnr-xfs/src/device_handle/inner.rs
@@ -734,4 +734,12 @@ impl DeviceHandle {
         usb.write_call(&call)?;
         usb.read_response(call.name()?)?.try_into()
     }
+
+    pub(crate) fn get_restart_history_inner(&self) -> Result<SystemRestartHistory> {
+        let call = XfsMethodCall::create(XfsMethodName::GetRestartHistory, []);
+        let usb = self.usb();
+
+        usb.write_call(&call)?;
+        usb.read_response(call.name()?)?.try_into()
+    }
 }

--- a/bnr-xfs/src/history.rs
+++ b/bnr-xfs/src/history.rs
@@ -10,6 +10,7 @@ mod loader_acceptance_history;
 mod loader_slot_acceptance_history;
 mod recognition_reject_details;
 mod system_failure_history;
+mod system_restart_history;
 mod transport_reject_details;
 
 pub use bill_acceptance_history::*;
@@ -24,4 +25,5 @@ pub use loader_acceptance_history::*;
 pub use loader_slot_acceptance_history::*;
 pub use recognition_reject_details::*;
 pub use system_failure_history::*;
+pub use system_restart_history::*;
 pub use transport_reject_details::*;

--- a/bnr-xfs/src/history/system_restart_history.rs
+++ b/bnr-xfs/src/history/system_restart_history.rs
@@ -1,0 +1,59 @@
+use crate::create_xfs_struct;
+use crate::xfs::method_response::XfsMethodResponse;
+use crate::{
+    BillIntakeCoverCount, CashModulesLockCount, Error, InternalResetCount,
+    InternalResetWithBillStoppedCount, PowerDownWithBillStoppedCount, PowerUpCount,
+    RecognitionSensorCoverCount, Result, SpineCoverCount, SystemOpeningCount, WithBillStoppedCount,
+};
+
+create_xfs_struct!(
+    SystemOpeningDetails,
+    "systemOpeningDetails",
+    [
+        with_bill_stopped_count: WithBillStoppedCount,
+        cash_modules_lock_count: CashModulesLockCount,
+        bill_intake_cover_count: BillIntakeCoverCount,
+        recognition_sensor_cover_count: RecognitionSensorCoverCount,
+        spine_cover_count: SpineCoverCount
+    ],
+    "Represents the system opening details."
+);
+
+create_xfs_struct!(
+    SystemRestartHistory,
+    "systemRestartHistory",
+    [
+        power_up_count: PowerUpCount,
+        power_down_with_bill_stopped_count: PowerDownWithBillStoppedCount,
+        internal_reset_count: InternalResetCount,
+        internal_reset_with_bill_stopped_count: InternalResetWithBillStoppedCount,
+        system_opening_count: SystemOpeningCount,
+        system_opening_details: SystemOpeningDetails
+    ],
+    "Represents the history of system restart events."
+);
+
+impl TryFrom<&XfsMethodResponse> for SystemRestartHistory {
+    type Error = Error;
+
+    fn try_from(val: &XfsMethodResponse) -> Result<Self> {
+        val.as_params()?
+            .params()
+            .iter()
+            .map(|m| m.inner())
+            .find(|m| m.value().xfs_struct().is_some())
+            .ok_or(Error::Xfs(format!(
+                "Expected SystemRestartHistory XfsMethodResponse, have: {val}"
+            )))?
+            .value()
+            .try_into()
+    }
+}
+
+impl TryFrom<XfsMethodResponse> for SystemRestartHistory {
+    type Error = Error;
+
+    fn try_from(val: XfsMethodResponse) -> Result<Self> {
+        (&val).try_into()
+    }
+}

--- a/bnr-xfs/src/xfs/method_call.rs
+++ b/bnr-xfs/src/xfs/method_call.rs
@@ -284,6 +284,8 @@ pub enum XfsMethodName {
     GetBillDispenseHistory,
     #[serde(rename = "bnr.getfailurehistory")]
     GetFailureHistory,
+    #[serde(rename = "bnr.getrestarthistory")]
+    GetRestartHistory,
     // **NOTE**: `Occured` is not a typo here, it is a mispelling in the protocol message that we have to replicate
     #[serde(rename = "BnrListener.operationCompleteOccured")]
     OperationCompleteOccurred,
@@ -336,6 +338,7 @@ impl From<&XfsMethodName> for &'static str {
             XfsMethodName::GetBillAcceptanceHistory => "bnr.getbillacceptancehistory",
             XfsMethodName::GetBillDispenseHistory => "bnr.getbilldispensehistory",
             XfsMethodName::GetFailureHistory => "bnr.getfailurehistory",
+            XfsMethodName::GetRestartHistory => "bnr.getrestarthistory",
             XfsMethodName::OperationCompleteOccurred => "BnrListener.operationCompleteOccured",
             XfsMethodName::IntermediateOccurred => "BnrListener.intermediateOccured",
             XfsMethodName::StatusOccurred => "BnrListener.statusOccured",
@@ -385,6 +388,7 @@ impl TryFrom<&str> for XfsMethodName {
             "bnr.getbillacceptancehistory" => Ok(Self::GetBillAcceptanceHistory),
             "bnr.getbilldispensehistory" => Ok(Self::GetBillDispenseHistory),
             "bnr.getfailurehistory" => Ok(Self::GetFailureHistory),
+            "bnr.getrestarthistory" => Ok(Self::GetRestartHistory),
             "bnrlistener.operationcompleteoccured" => Ok(Self::OperationCompleteOccurred),
             "bnrlistener.intermediateoccured" => Ok(Self::IntermediateOccurred),
             "bnrlistener.statusoccured" => Ok(Self::StatusOccurred),

--- a/bnr-xfs/tests/e2e_tests/history.rs
+++ b/bnr-xfs/tests/e2e_tests/history.rs
@@ -61,3 +61,23 @@ fn test_get_failure_history() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_get_restart_history() -> Result<()> {
+    let _lock = common::init();
+
+    let handle = DeviceHandle::open(None, None, None)?;
+
+    handle.close()?;
+
+    let date = handle.get_date_time()?;
+    if date.year() == 2001 {
+        handle.set_current_date_time()?;
+    }
+
+    let history = handle.get_restart_history()?;
+
+    log::debug!("System restart history: {history}");
+
+    Ok(())
+}


### PR DESCRIPTION
Adds the `DeviceHistory::get_restart_history` method call to get the history of system restart events.