### PR TITLE
bnr-xfs: add get use history call

### DIFF
--- a/bnr-xfs/src/device_handle.rs
+++ b/bnr-xfs/src/device_handle.rs
@@ -13,6 +13,7 @@ use crate::denominations::DenominationList;
 use crate::dispense::DispenseRequest;
 use crate::history::{
     BillAcceptanceHistory, BillDispenseHistory, SystemFailureHistory, SystemRestartHistory,
+    SystemUseHistory,
 };
 use crate::status::CdrStatus;
 use crate::xfs;
@@ -524,6 +525,11 @@ impl DeviceHandle {
     /// Gets the BNR [SystemRestartHistory].
     pub fn get_restart_history(&self) -> Result<SystemRestartHistory> {
         self.get_restart_history_inner()
+    }
+
+    /// Gets the BNR [SystemUseHistory].
+    pub fn get_use_history(&self) -> Result<SystemUseHistory> {
+        self.get_use_history_inner()
     }
 
     /// Gets a reference to the [UsbDeviceHandle].

--- a/bnr-xfs/src/device_handle/inner.rs
+++ b/bnr-xfs/src/device_handle/inner.rs
@@ -742,4 +742,12 @@ impl DeviceHandle {
         usb.write_call(&call)?;
         usb.read_response(call.name()?)?.try_into()
     }
+
+    pub(crate) fn get_use_history_inner(&self) -> Result<SystemUseHistory> {
+        let call = XfsMethodCall::create(XfsMethodName::GetUseHistory, []);
+        let usb = self.usb();
+
+        usb.write_call(&call)?;
+        usb.read_response(call.name()?)?.try_into()
+    }
 }

--- a/bnr-xfs/src/history.rs
+++ b/bnr-xfs/src/history.rs
@@ -11,6 +11,7 @@ mod loader_slot_acceptance_history;
 mod recognition_reject_details;
 mod system_failure_history;
 mod system_restart_history;
+mod system_use_history;
 mod transport_reject_details;
 
 pub use bill_acceptance_history::*;
@@ -26,4 +27,5 @@ pub use loader_slot_acceptance_history::*;
 pub use recognition_reject_details::*;
 pub use system_failure_history::*;
 pub use system_restart_history::*;
+pub use system_use_history::*;
 pub use transport_reject_details::*;

--- a/bnr-xfs/src/history/system_use_history.rs
+++ b/bnr-xfs/src/history/system_use_history.rs
@@ -1,0 +1,100 @@
+use crate::xfs::method_response::XfsMethodResponse;
+use crate::{create_xfs_array, create_xfs_date_time, create_xfs_i4, create_xfs_struct};
+use crate::{Error, Result};
+
+const SENSOR_TEMPS_LEN: usize = 4;
+const SENSOR_TEMP_DEFAULT: SensorTemperature = SensorTemperature::new();
+
+create_xfs_date_time!(
+    CurrentDateTime,
+    "currentDateTime",
+    "Represents the device current date time."
+);
+
+create_xfs_i4!(UpTime, "upTime", "Represents the device up time.");
+
+create_xfs_i4!(
+    TotalUpTime,
+    "totalUpTime",
+    "Represents the device total up time."
+);
+
+create_xfs_i4!(
+    TimeSinceOperational,
+    "timeSinceOperational",
+    "Represents the device time since operational."
+);
+
+create_xfs_i4!(
+    SystemCycleCount,
+    "systemCycleCount",
+    "Represents the device system cycle count."
+);
+
+create_xfs_i4!(
+    SystemTemperature,
+    "systemTemperature",
+    "Represents the device system temperature."
+);
+
+create_xfs_i4!(
+    SensorTemperature,
+    "",
+    "Represents a device sensor temperature."
+);
+
+create_xfs_array!(
+    RecognitionSensorTemperatures,
+    "recognitionSensorTemperatures",
+    SensorTemperature,
+    SENSOR_TEMPS_LEN,
+    SENSOR_TEMP_DEFAULT,
+    "Represents the device recognition sensor temperatures."
+);
+
+create_xfs_i4!(
+    PowerSupplyVoltage,
+    "powerSupplyVoltage",
+    "Represents a device power supply voltage."
+);
+
+create_xfs_struct!(
+    SystemUseHistory,
+    "systemUseHistory",
+    [
+        current_date_time: CurrentDateTime,
+        up_time: UpTime,
+        total_up_time: TotalUpTime,
+        time_since_operational: TimeSinceOperational,
+        system_cycle_count: SystemCycleCount,
+        system_temperature: SystemTemperature,
+        recognition_sensor_temperatures: RecognitionSensorTemperatures,
+        power_supply_voltage: PowerSupplyVoltage
+    ],
+    "Represents the system use history."
+);
+
+impl TryFrom<&XfsMethodResponse> for SystemUseHistory {
+    type Error = Error;
+
+    fn try_from(val: &XfsMethodResponse) -> Result<Self> {
+        val.as_params()?
+            .params()
+            .iter()
+            .map(|m| m.inner())
+            .find(|m| m.value().xfs_struct().is_some())
+            .ok_or(Error::Xfs(format!(
+                "Expected SystemUseHistory XfsMethodResponse, have: {val}"
+            )))?
+            .value()
+            .try_into()
+    }
+}
+
+impl TryFrom<XfsMethodResponse> for SystemUseHistory {
+    type Error = Error;
+
+    fn try_from(val: XfsMethodResponse) -> Result<Self> {
+        (&val).try_into()
+    }
+}

--- a/bnr-xfs/src/xfs/method_call.rs
+++ b/bnr-xfs/src/xfs/method_call.rs
@@ -286,6 +286,8 @@ pub enum XfsMethodName {
     GetFailureHistory,
     #[serde(rename = "bnr.getrestarthistory")]
     GetRestartHistory,
+    #[serde(rename = "bnr.getusehistory")]
+    GetUseHistory,
     // **NOTE**: `Occured` is not a typo here, it is a mispelling in the protocol message that we have to replicate
     #[serde(rename = "BnrListener.operationCompleteOccured")]
     OperationCompleteOccurred,
@@ -339,6 +341,7 @@ impl From<&XfsMethodName> for &'static str {
             XfsMethodName::GetBillDispenseHistory => "bnr.getbilldispensehistory",
             XfsMethodName::GetFailureHistory => "bnr.getfailurehistory",
             XfsMethodName::GetRestartHistory => "bnr.getrestarthistory",
+            XfsMethodName::GetUseHistory => "bnr.getusehistory",
             XfsMethodName::OperationCompleteOccurred => "BnrListener.operationCompleteOccured",
             XfsMethodName::IntermediateOccurred => "BnrListener.intermediateOccured",
             XfsMethodName::StatusOccurred => "BnrListener.statusOccured",
@@ -389,6 +392,7 @@ impl TryFrom<&str> for XfsMethodName {
             "bnr.getbilldispensehistory" => Ok(Self::GetBillDispenseHistory),
             "bnr.getfailurehistory" => Ok(Self::GetFailureHistory),
             "bnr.getrestarthistory" => Ok(Self::GetRestartHistory),
+            "bnr.getusehistory" => Ok(Self::GetUseHistory),
             "bnrlistener.operationcompleteoccured" => Ok(Self::OperationCompleteOccurred),
             "bnrlistener.intermediateoccured" => Ok(Self::IntermediateOccurred),
             "bnrlistener.statusoccured" => Ok(Self::StatusOccurred),

--- a/bnr-xfs/tests/e2e_tests/history.rs
+++ b/bnr-xfs/tests/e2e_tests/history.rs
@@ -81,3 +81,24 @@ fn test_get_restart_history() -> Result<()> {
 
     Ok(())
 }
+
+#[test]
+fn test_get_use_history() -> Result<()> {
+    let _lock = common::init();
+
+    let handle = DeviceHandle::open(None, None, None)?;
+
+    handle.close()?;
+
+    let date = handle.get_date_time()?;
+    if date.year() == 2001 {
+        handle.set_current_date_time()?;
+    }
+
+    let history = handle.get_use_history()?;
+
+    log::debug!("System use history: {history}");
+    log::debug!("System current time: {}", time::OffsetDateTime::try_from(history.current_date_time())?);
+
+    Ok(())
+}


### PR DESCRIPTION
Adds the `DeviceHandle::get_use_history` method call and related types to get the history of use events.

Adds helper macros to create XFS `string` and `datetime` types.