### PR TITLE
version: bump to 0.1.3

### DIFF
--- a/bnr-xfs/Cargo.toml
+++ b/bnr-xfs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bnr-xfs"
-version = "0.1.2"
+version = "0.1.3"
 edition = "2021"
 authors = ["BNR Rust Developers"]
 description = "Pure Rust implementation of the BNR XFS USB"


### PR DESCRIPTION
Bumps the patch release version to include history method calls.