### PR TITLE
version: bump to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bnr"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 authors = ["BNR Rust Developers"]
 description = "Pure Rust implementation of the BNR XFS USB communication protocol"


### PR DESCRIPTION
Bumps the patch release version to include history functions.